### PR TITLE
[WIP] Initial support for workspaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,6 +86,8 @@ dependencies = [
  "minimad",
  "notify",
  "regex",
+ "serde",
+ "serde_json",
  "simplelog",
  "termimad",
 ]
@@ -360,6 +362,12 @@ checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "itoa"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 
 [[package]]
 name = "kernel32-sys"
@@ -652,6 +660,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -665,6 +679,37 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "serde"
+version = "1.0.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b88fa983de7720629c9387e9f517353ed404164b1e482c970a90c1a4aaf7dc1a"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbd1ae72adb44aab48f325a02444a5fc079349a8d804c1fc922aed3f7454c74e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.59"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcac07dbffa1c65e7f816ab9eba78eb142c6d44410f4eeba1e26e4f5dfa56b95"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
 
 [[package]]
 name = "signal-hook"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,14 +80,13 @@ version = "0.2.3"
 dependencies = [
  "anyhow",
  "argh",
+ "cargo_metadata",
  "crossbeam",
  "crossterm",
  "log",
  "minimad",
  "notify",
  "regex",
- "serde",
- "serde_json",
  "simplelog",
  "termimad",
 ]
@@ -113,6 +112,17 @@ dependencies = [
  "arrayref",
  "arrayvec",
  "constant_time_eq",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5a5f7b42f606b7f23674f6f4d877628350682bc40687d3fae65679a58d55345"
+dependencies = [
+ "semver",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -595,6 +605,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pest"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
+dependencies = [
+ "ucd-trie",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -679,6 +698,25 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "semver"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+dependencies = [
+ "semver-parser",
+ "serde",
+]
+
+[[package]]
+name = "semver-parser"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ef146c2ad5e5f4b037cd6ce2ebb775401729b19a82040c1beac9d36c7d1428"
+dependencies = [
+ "pest",
+]
 
 [[package]]
 name = "serde"
@@ -840,6 +878,12 @@ dependencies = [
  "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi 0.3.9",
 ]
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "unicode-segmentation"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,6 @@ log = "0.4"
 regex = "1.3"
 simplelog = "0.7"
 termimad = "0.8.28"
+serde = {version="1.0", features=["derive"]}
+serde_json = "1.0"
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,4 @@ log = "0.4"
 regex = "1.3"
 simplelog = "0.7"
 termimad = "0.8.28"
-serde = {version="1.0", features=["derive"]}
-serde_json = "1.0"
-
+cargo_metadata = "0.12"

--- a/src/app.rs
+++ b/src/app.rs
@@ -15,17 +15,120 @@ use {
         fs,
         io::Write,
         path::PathBuf,
+        process::Command
     },
+    serde::{Serialize, Deserialize},
     termimad::{Event, EventSource},
 };
 
+// Represents a subset of JSON returned by `cargo metadata`
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct CargoMetadata {
+    #[serde(rename = "packages")]
+    packages: Vec<Package>,
+
+    #[serde(rename = "workspace_members")]
+    workspace_members: Vec<String>,
+
+    #[serde(rename = "target_directory")]
+    target_directory: String,
+
+    #[serde(rename = "version")]
+    version: i64,
+
+    #[serde(rename = "workspace_root")]
+    workspace_root: String,
+
+    #[serde(rename = "metadata")]
+    metadata: Option<serde_json::Value>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Package {
+    #[serde(rename = "name")]
+    name: String,
+
+    #[serde(rename = "version")]
+    version: String,
+
+    #[serde(rename = "id")]
+    id: String,
+
+    #[serde(rename = "license")]
+    license: Option<String>,
+
+    #[serde(rename = "license_file")]
+    license_file: Option<String>,
+
+    #[serde(rename = "description")]
+    description: Option<String>,
+
+    #[serde(rename = "targets")]
+    targets: Vec<Target>,
+
+    #[serde(rename = "source")]
+    source: Option<String>,
+
+    #[serde(rename = "manifest_path")]
+    manifest_path: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Target {
+    #[serde(rename = "name")]
+    name: String,
+
+    #[serde(rename = "src_path")]
+    src_path: String,
+
+    #[serde(rename = "edition")]
+    edition: String,
+
+    #[serde(rename = "doctest")]
+    doctest: bool,
+
+    #[serde(rename = "required-features")]
+    required_features: Option<Vec<String>>,
+}
+
+fn find_folders_to_watch(root_dir:&PathBuf)->Result<Vec<PathBuf>>{
+
+    let output = Command::new("cargo").current_dir(root_dir).arg("metadata").arg("--format-version").arg("1").output()?;
+
+    let output_string = String::from_utf8(output.stdout)?;
+    let metadata:CargoMetadata = serde_json::from_str(&output_string)?;
+
+    let mut folders_to_watch = vec![];
+    for item in metadata.packages{
+        if item.source.is_none(){
+            // We're only concerned with items where the source is None
+            for target in item.targets{
+                if target.src_path.ends_with("lib.rs") || target.src_path.ends_with("main.rs"){
+                    // targets can contain the build script as well, so we need to eliminate them.
+
+                    let target_folder = PathBuf::from_str(&target.src_path)?;
+                    let target_folder_parent = PathBuf::from(target_folder.parent().expect("parent of target is a root folder."));
+                    if target_folder_parent.ends_with("src"){
+                        // to ensure misc binaries are not counted, such as
+                        // src/binaries/foo_main.rs
+                        folders_to_watch.push(target_folder_parent)
+                    }
+                }
+            }
+        }
+    }
+    Ok(folders_to_watch)
+}
+
 pub fn run(w: &mut W, args: Args) -> Result<()> {
+
     let root_dir = args.root.unwrap_or_else(||env::current_dir().unwrap());
     let root_dir: PathBuf = fs::canonicalize(&root_dir)?;
+    let src_dirs = find_folders_to_watch(&root_dir).unwrap();
     debug!("root_dir: {:?}", &root_dir);
-    let src_dir = root_dir.join("src");
     let cargo_toml_file = root_dir.join("Cargo.toml");
-    if !src_dir.exists() || !cargo_toml_file.exists() {
+    if !cargo_toml_file.exists() {
         return Err(anyhow!(
             "bacon must be launched either\n\
             * in a rust project directory\n\
@@ -56,7 +159,10 @@ pub fn run(w: &mut W, args: Args) -> Result<()> {
         }
         Err(e) => warn!("watch error: {:?}", e),
     })?;
-    watcher.watch(src_dir, RecursiveMode::Recursive)?;
+
+    for src_dir in src_dirs.iter(){
+        watcher.watch(src_dir, RecursiveMode::Recursive)?;
+    }
     watcher.watch(cargo_toml_file, RecursiveMode::NonRecursive)?;
 
     let computer = Computer::new(root_dir, args.clippy)?;

--- a/src/app.rs
+++ b/src/app.rs
@@ -45,7 +45,7 @@ pub fn run(w: &mut W, args: Args) -> Result<()> {
     let root_dir = args.root.unwrap_or_else(|| env::current_dir().unwrap());
     let root_dir: PathBuf = fs::canonicalize(&root_dir)?;
     let cargo_toml_file = root_dir.join("Cargo.toml");
-    let src_dirs = find_folders_to_watch(&cargo_toml_file).unwrap();
+    let src_dirs = find_folders_to_watch(&cargo_toml_file).expect("Getting cargo metadata");
     debug!("root_dir: {:?}", &root_dir);
     if !cargo_toml_file.exists() {
         return Err(anyhow!(

--- a/src/computer.rs
+++ b/src/computer.rs
@@ -2,11 +2,7 @@ use {
     crate::*,
     anyhow::*,
     crossbeam::channel::{bounded, select, unbounded, Receiver, Sender},
-    std::{
-        env,
-        path::PathBuf,
-        thread,
-    },
+    std::{env, path::PathBuf, thread},
 };
 
 pub struct Computer {

--- a/src/state.rs
+++ b/src/state.rs
@@ -32,11 +32,7 @@ impl AppState {
         status_skin.paragraph.set_bg(DarkGrey);
         status_skin.italic = CompoundStyle::with_fg(Yellow);
         Ok(Self {
-            name: root_dir
-                .file_name()
-                .unwrap()
-                .to_string_lossy()
-                .to_string(),
+            name: root_dir.file_name().unwrap().to_string_lossy().to_string(),
             report: None,
             screen: termimad::terminal_size(),
             computing: true,
@@ -145,7 +141,7 @@ impl AppState {
             }
         }
         goto(w, self.screen.1)?;
-        let status =  "hit *q* to quit, *s* to toggle summary mode";
+        let status = "hit *q* to quit, *s* to toggle summary mode";
         self.status_skin.write_composite_fill(
             w,
             Composite::from_inline(status),


### PR DESCRIPTION
Adds support for workspaces by parsing `cargo metadata` and filtering the targets to find the `src/` directories of the workspace members.

Adds dependancy on `serde` and `serde_json` to parse the metadata.