### PR TITLE
Change `check-all` to actually check all targets

### DIFF
--- a/src/default_package_config.rs
+++ b/src/default_package_config.rs
@@ -11,7 +11,7 @@ command = ["cargo", "check", "--color", "always"]
 need_stdout = false
 
 [jobs.check-all]
-command = ["cargo", "check", "--tests", "--color", "always"]
+command = ["cargo", "check", "--all-targets", "--color", "always"]
 need_stdout = false
 
 [jobs.light]


### PR DESCRIPTION
Previously, it would only check tests and the main library. This includes binaries, examples, and benchmarks.

I think this counts as fixing https://github.com/Canop/bacon/issues/27, not sure if you had other plans for it.