### PR TITLE
Print an error in --init if bacon.toml already exists

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,6 @@
 use {
     crate::*,
+    anyhow::anyhow,
     crossterm::{
         self, cursor,
         terminal::{EnterAlternateScreen, LeaveAlternateScreen},
@@ -66,6 +67,8 @@ pub fn run() -> anyhow::Result<()> {
         if !package_config_path.exists() {
             fs::write(&package_config_path, DEFAULT_PACKAGE_CONFIG)?;
             eprintln!("bacon project configuration file written.");
+        } else {
+            return Err(anyhow!("{} already exists, refusing to overwrite", package_config_path.display()).into());
         }
         println!("{}", package_config_path.to_string_lossy());
         return Ok(());


### PR DESCRIPTION
Example output:

```
Error: /home/joshua/src/rust/bacon/bacon.toml already exists, refusing to overwrite
```

Closes https://github.com/Canop/bacon/issues/34