### PR TITLE
Add README section about check-all option

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ or
 
     bacon ../broot
 
+### check all targets (tests, examples, etc)
+
+    bacon --job check-all
+
+or
+
+    bacon check-all
+
 ### run clippy instead of cargo check
 
     bacon --job clippy


### PR DESCRIPTION
I wasn't aware of that option, and there was no way to discover it from the command line.

I only found it by looking through the code.