### PR TITLE
Watch examples directory if it exists

### DIFF
--- a/src/mission.rs
+++ b/src/mission.rs
@@ -112,6 +112,12 @@ impl Mission {
                     } else {
                         warn!("missing src dir: {:?}", src_dir);
                     }
+                    let examples_dir = item_path.join("examples");
+                    if examples_dir.exists() {
+                        directories_to_watch.push(examples_dir);
+                    } else {
+                        debug!("missing examples dir: {:?}", examples_dir);
+                    }
                 }
                 if item.manifest_path.exists() {
                     files_to_watch.push(item.manifest_path);


### PR DESCRIPTION
While the examples can be checked by `--check-all-targets` (#33) or `--examples` (which would be a nice addition to the default jobs), the examples directory is currently not watched by the watching mechanism. The change in this PR causes examples to be watched on my machine.