### PR TITLE
Allow specifying watch directories in bacon.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,14 @@ This file already contains some standard jobs. Add your own, for example
 command = ["cargo", "check", "--target", "x86_64-pc-windows-gnu", "--color", "always"]
 ```
 
+or
+
+```toml
+[jobs.check-examples]
+command = ["cargo", "check", "--examples", "--color", "always"]
+watch = ["examples"] # src is implicitly included
+```
+
 *Don't forget the `--color always` part: bacon uses style information to recognize warnings and errors.*
 
 and run

--- a/src/default_package_config.rs
+++ b/src/default_package_config.rs
@@ -13,6 +13,7 @@ need_stdout = false
 [jobs.check-all]
 command = ["cargo", "check", "--all-targets", "--color", "always"]
 need_stdout = false
+watch = ["tests", "benches", "examples"]
 
 [jobs.light]
 command = ["cargo", "check", "--color", "always"]
@@ -25,5 +26,6 @@ need_stdout = false
 [jobs.test]
 command = ["cargo", "test", "--color", "always"]
 need_stdout = true
+watch = ["tests"]
 
 "#;

--- a/src/job.rs
+++ b/src/job.rs
@@ -9,6 +9,12 @@ pub struct Job {
     /// by the PackageConfig::from_path loader
     pub command: Vec<String>,
 
+    /// A list of directories that will be watched if the job
+    /// is run on a package.
+    /// src is implicitly included.
+    #[serde(default)]
+    pub watch: Vec<String>,
+
     /// whether we need to capture stdout too (stderr is
     /// always captured)
     #[serde(default)]

--- a/src/mission.rs
+++ b/src/mission.rs
@@ -7,6 +7,7 @@ use {
         collections::HashSet,
         env,
         fs,
+        iter,
         path::PathBuf,
         process::Command,
     },
@@ -106,11 +107,15 @@ impl Mission {
                     .parent()
                     .expect("parent of a target folder is a root folder");
                 if add_all_src {
-                    let src_dir = item_path.join("src");
-                    if src_dir.exists() {
-                        directories_to_watch.push(src_dir);
-                    } else {
-                        warn!("missing src dir: {:?}", src_dir);
+                    let src_watch_iter = iter::once("str");
+                    let other_watch_iter = job.watch.iter().map(String::as_ref);
+                    for dir in src_watch_iter.chain(other_watch_iter) {
+                        let full_path = item_path.join(dir);
+                        if full_path.exists() {
+                            directories_to_watch.push(full_path);
+                        } else {
+                            warn!("missing {} dir: {:?}", dir, full_path);
+                        }
                     }
                 }
                 if item.manifest_path.exists() {


### PR DESCRIPTION
Allows specifying additional watch directories in a job. Closes #39.

I wasn't sure whether to combine the `src` with the iterator like this or just repeat the code block. Happy to change it.

Just to note, this _will_ `warn!` about missing benches, tests, and examples when you run `check-all`. If that should be `info!` or `debug!`, splitting the handling of `src` and other definitely makes sense, IMO.

Also, if I missed any doc updates that are needed, let me know.