### PR TITLE
Add a `bacon doc` task

### DIFF
--- a/defaults/default-bacon.toml
+++ b/defaults/default-bacon.toml
@@ -22,3 +22,7 @@ need_stdout = false
 command = ["cargo", "test", "--color", "always"]
 need_stdout = true
 watch = ["tests"]
+
+[jobs.doc]
+command = ["cargo", "doc", "--color", "always", "--no-deps"]
+need_stdout = false


### PR DESCRIPTION
I have been using this a bunch, it works really well. It even shows the unresolved `[doc_links::to_stuff]` warnings. `cargo doc` is blazing fast, so you can tweak docs and refresh the browser in under a second. I would highly recommend trying this out and including it by default.

Also something i've been using, which is awesome but probably not a default:

```toml
[jobs.docs-rs]
command = [
  "env",
  "RUSTDOCFLAGS=--cfg docsrs",
  "cargo",
  "+nightly",
  "doc",
  "--color", "always",
  "--no-deps",
  "--all-features",
]
```

Then you can preview with the same `--cfg docsrs` that you can configure via the Cargo.toml `[package.metadata.docs.rs]` options, and get the whole "this is only available with feature XXX" notices in your doc previews. (docs rs builds on nightly so the `doc_cfg` feature is available.) For anyone wanting to try, it's:

```toml
[package.metadata.docs.rs]
all-features = true # if you want
rustdoc-args = ["--cfg", "docsrs"]
```

And then

```rust
// crate root
#![cfg_attr(docsrs, feature(doc_cfg))]

// on items
#[cfg(feature = "feature-name")]
#[cfg_attr(docsrs, doc(cfg(feature = "feature-name")))]
struct S;
```

(I'm guessing this will be stabilised at some point, and then regular `bacon doc` would work if you remove the cfg_attr wrapping.)