### PR TITLE
Add a --workspace flag, to check entire workspace

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -57,7 +57,7 @@ pub struct Args {
     /// check all members in the workspace.
     ///
     /// Equivalent to `cargo check --workspace`
-    #[argh(switch)]
+    #[clap(long = "workspace")]
     pub workspace: bool,
 
     /// activate all available features

--- a/src/args.rs
+++ b/src/args.rs
@@ -54,6 +54,12 @@ pub struct Args {
     #[clap(long = "no-default-features")]
     pub no_default_features: bool,
 
+    /// check all members in the workspace.
+    ///
+    /// Equivalent to `cargo check --workspace`
+    #[argh(switch)]
+    pub workspace: bool,
+
     /// activate all available features
     #[clap(long = "all-features")]
     pub all_features: bool,

--- a/src/mission.rs
+++ b/src/mission.rs
@@ -158,6 +158,9 @@ impl<'s> Mission<'s> {
                 }
             }
         }
+        if self.settings.workspace {
+            command.arg("--workspace");
+        }
         command.current_dir(&self.cargo_execution_directory);
         debug!("command: {:#?}", &command);
         command

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -16,6 +16,7 @@ pub struct Settings {
     pub wrap: bool,
     pub reverse: bool,
     pub no_default_features: bool,
+    pub workspace: bool,
     pub all_features: bool,
     pub features: Option<String>, // comma separated list
     pub keybindings: KeyBindings,
@@ -76,5 +77,8 @@ impl Settings {
             self.features = args.features.clone();
         }
         self.additional_job_args = args.additional_job_args.clone();
+        if args.workspace {
+            self.workspace = true;
+        }
     }
 }


### PR DESCRIPTION
This simply forwards to the --workspace flag
of cargo check and clippy.

I find this very useful when using `cargo check`
directly, so I figured it'd be nice to have here :)
