### PR TITLE
Add clippy-all to default-bacon.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,14 @@ or
 
     bacon clippy
 
+### run clippy instead of cargo check and run against all targets (tests, examples, benches etc)
+
+    bacon --job clippy-all
+
+or
+
+    bacon clippy-all
+
 ### run tests
 
     bacon test

--- a/defaults/default-bacon.toml
+++ b/defaults/default-bacon.toml
@@ -18,6 +18,11 @@ watch = ["tests", "benches", "examples"]
 command = ["cargo", "clippy", "--color", "always"]
 need_stdout = false
 
+[jobs.clippy-all]
+command = ["cargo", "clippy", "--all-targets", "--color", "always"]
+need_stdout = false
+watch = ["tests", "benches", "examples"]
+
 [jobs.test]
 command = ["cargo", "test", "--color", "always"]
 need_stdout = true


### PR DESCRIPTION
This is a real fairly subjective change so i'm happy to change things.

But I do feel strongly that the most aggressive config (running clippy on everything) is a highly desirable default to have.