### PR TITLE
use asynchronous IO in the executor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,6 +56,7 @@ dependencies = [
  "notify",
  "serde",
  "termimad",
+ "tokio",
  "toml",
  "unicode-width",
  "vte",
@@ -66,6 +67,12 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bytes"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "camino"
@@ -630,6 +637,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e280fbe77cc62c91527259e9442153f4688736748d24660126286329742b4c6c"
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -888,6 +901,34 @@ checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "tokio"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af73ac49756f3f7c01172e34a23e5d0216f6c32333757c2c61feb2bbff5a5ee"
+dependencies = [
+ "bytes",
+ "libc",
+ "memchr",
+ "mio 0.8.2",
+ "once_cell",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "tokio-macros",
+ "winapi",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ termimad = "0.20"
 toml = "0.5.8"
 unicode-width = "0.1.9"
 vte = "0.8"
+tokio = { version = "1.17.0", default-features = false, features = ["sync", "process", "rt", "macros", "io-util"] }
 
 [profile.release]
 lto = true

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -91,7 +91,8 @@ impl Executor {
                                 Ok(child) => child,
                             };
 
-                            current_task = Some(tokio::spawn(                                execute_task(child, with_stdout, line_sender.clone())
+                            current_task = Some(tokio::spawn(
+                                execute_task(child, with_stdout, line_sender.clone())
                             ));
                         }
 
@@ -186,7 +187,11 @@ async fn execute_task(
             .take()
             .ok_or_else(|| anyhow!("child missing stdout"))?;
         let stdout_sender = line_sender.clone();
-        Some(stream_consumer(stdout, CommandStream::StdOut, stdout_sender))
+        Some(stream_consumer(
+            stdout,
+            CommandStream::StdOut,
+            stdout_sender,
+        ))
     } else {
         None
     };


### PR DESCRIPTION
This is my second attempt at fixing #78. 

At first, I thought it would be enough to just call `Child::kill` upon receiving the stop signal in the executor (https://github.com/nolanderc/bacon/commit/07ab3184e2f870d75d36b26380375c0510409539). However, this didn't work, as it didn't fully close the `stderr` and `stdout` streams and thus kept the threads open in the background, still deadlocked.

This version uses `async` in order to cleanly cancel the currently running task. This does mean an extra dependency on `tokio`, but I've tried to keep the number of features down as much as reasonably possible.