### PR TITLE
feat: Use cargo aliases through `--alias <alias>`

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -9,7 +9,6 @@ use {
 /// Documentation at <https://dystroy.org/bacon>
 #[clap(version, about)]
 pub struct Args {
-
     /// print the path to the prefs file, create it if it doesn't exist
     #[clap(long = "prefs")]
     pub prefs: bool,
@@ -49,6 +48,18 @@ pub struct Args {
     /// job to launch ("check", "clippy", customized ones, ...)
     #[clap(short = 'j', long = "job")]
     pub job: Option<String>,
+
+    /// alias to launch (bacon does not check its existence before
+    /// attempting to launch it). Adds `--color=always` by default,
+    /// use `--no-default-alias-args` to remove it.
+    ///
+    /// Checked before `--job`
+    #[clap(short = 'a', long = "alias")]
+    pub alias: Option<String>,
+
+    /// do not add `--color=always` to the `--alias` argument
+    #[clap(long = "no-default-alias-args")]
+    pub no_default_alias_args: bool,
 
     /// ignore features of both the package and the bacon job
     #[clap(long = "no-default-features")]

--- a/src/job.rs
+++ b/src/job.rs
@@ -28,3 +28,22 @@ pub struct Job {
     #[serde(default)]
     pub on_success: Option<Action>,
 }
+
+impl Job {
+    /// Builds a `Job` from a cargo alias. The user is expected to know what
+    /// they are doing here.
+    pub fn from_alias(alias_name: &str, settings: &Settings) -> Self {
+        let mut command = vec!["cargo".to_string(), alias_name.to_string()];
+
+        if !settings.no_default_alias_args {
+            command.extend_from_slice(&["--color".to_string(), "always".to_string()]);
+        }
+
+        Self {
+            command,
+            watch: Vec::new(),
+            need_stdout: false,
+            on_success: None,
+        }
+    }
+}

--- a/src/job_ref.rs
+++ b/src/job_ref.rs
@@ -1,13 +1,13 @@
-use {
-    std::fmt,
-};
+use std::fmt;
+
+use crate::JobType;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum JobRef {
     Default,
     Initial,
     Previous,
-    Name(String), // should be neither "initial", "default" or "previous"
+    Type(JobType), // should be neither "initial", "default" or "previous"
 }
 
 impl fmt::Display for JobRef {
@@ -16,7 +16,7 @@ impl fmt::Display for JobRef {
             Self::Default => write!(f, "default"),
             Self::Initial => write!(f, "initial"),
             Self::Previous => write!(f, "previous"),
-            Self::Name(name) => write!(f, "{name:?}"),
+            Self::Type(name) => write!(f, "\"{name}\""),
         }
     }
 }
@@ -27,7 +27,7 @@ impl From<&str> for JobRef {
             "default" => Self::Default,
             "initial" => Self::Initial,
             "previous" => Self::Previous,
-            _ => Self::Name(name.to_string()),
+            _ => Self::Type(JobType::Job(name.to_string())),
         }
     }
 }

--- a/src/mission.rs
+++ b/src/mission.rs
@@ -15,7 +15,7 @@ use {
 #[derive(Debug)]
 pub struct Mission<'s> {
     pub location_name: String,
-    pub job_name: String,
+    pub job_type: JobType,
     pub cargo_execution_directory: PathBuf,
     job: Job,
     files_to_watch: Vec<PathBuf>,
@@ -26,7 +26,7 @@ pub struct Mission<'s> {
 impl<'s> Mission<'s> {
     pub fn new(
         location: &MissionLocation,
-        job_name: String,
+        job_type: JobType,
         job: Job,
         settings: &'s Settings,
     ) -> Result<Self> {
@@ -66,7 +66,7 @@ impl<'s> Mission<'s> {
         let cargo_execution_directory = location.package_directory.clone();
         Ok(Mission {
             location_name,
-            job_name,
+            job_type,
             cargo_execution_directory,
             job,
             files_to_watch,

--- a/src/state.rs
+++ b/src/state.rs
@@ -316,7 +316,7 @@ impl<'s> AppState<'s> {
         let project_name = &self.mission.location_name;
         t_line.add_badge(TString::badge(project_name, 255, 240));
         // black over pink
-        t_line.add_badge(TString::badge(&self.mission.job_name, 235, 204));
+        t_line.add_badge(TString::badge(&self.mission.job_type.name(), 235, 204));
         if let CommandResult::Report(report) = &self.cmd_result {
             let stats = &report.stats;
             if stats.errors > 0 {


### PR DESCRIPTION
- Adds an `--alias <alias>` flag to run `cargo <alias>` through bacon
  - `--color always` is added to the command
  - Watched directories are not supported
  - "Needs stdout" is not supported
  - Running a command on success is not supported
- Adds `-no-default-alias-args` to remove the default behaviour of adding `--color always`

This is an MVP, their could be more work done to support the missing features, for example
by extending to `bacon.toml` to support an `is_alias` flag on jobs or maybe an `[alias]` section.

Fixes #77
