### PR TITLE
Show pass with warnings/hide pass when 0 passing tests

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -364,12 +364,11 @@ impl<'s> AppState<'s> {
             }
             if stats.test_fails > 0 {
                 t_line.add_badge(TString::num_badge(stats.test_fails, "fail", 235, 208));
+            } else if stats.passed_tests > 0 {
+                t_line.add_badge(TString::badge("pass!", 254, 2));
             }
             if stats.warnings > 0 {
                 t_line.add_badge(TString::num_badge(stats.warnings, "warning", 235, 11));
-            }
-            if stats.items() == 0 {
-                t_line.add_badge(TString::badge("pass!", 254, 2));
             }
         } else if let CommandResult::Failure(failure) = &self.cmd_result {
             t_line.add_badge(TString::badge(


### PR DESCRIPTION
Hello! This is in response to #108 with some code examples instead of just an ASCII representation of the badges.

The intent here is to make showing pass/fail more consistent, though while making these modifications I realized that `pass!` will currently show up in a project with 0 tests. 

To correct this, we only show the pass! badge when there is at least one passing test.


## Fail
![fail](https://user-images.githubusercontent.com/454563/218332143-bbd82225-fb6e-4043-98c7-1b47bbaaa285.png)


## Pass
![pass](https://user-images.githubusercontent.com/454563/218332147-21daf64e-a1f9-4bff-85be-31d87cdae664.png)


## No Tests
![image](https://user-images.githubusercontent.com/454563/218339624-ebfdf067-4321-494e-87dd-bf67e4093a30.png)


# Unnecessary Passes
Without this patch there are a number of places where `[pass!]` shows up erroneously.
![image](https://user-images.githubusercontent.com/454563/218339668-6ab8b440-61c7-4f23-96dd-b48541fb6ab7.png)
![image](https://user-images.githubusercontent.com/454563/218339672-0462802f-33c3-42af-a421-20f853fffa2e.png)
This can be misleading as you may have failing tests, but when you are in clippy mode you are presented with a false `pass!` badge even if you have failing tests as clippy does not run them.

This PR removes pass from displaying in these instances, as it will only show up if successful tests have been performed.