### PR TITLE
Offline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### next
 - change default value of 'wrap' setting to true
+- `--offline` experimental launch argument, prevents bacon (but not jobs) from accessing the network. Downside is a potentially less relevant list of watched files and directories - Fix #110
 
 <a name="v2.5.0"></a>
 ### v2.5.0 - 2023/01/19

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1396,9 +1396,9 @@ dependencies = [
 
 [[package]]
 name = "minimad"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "277639f0198568f70f8fe4ab88a52a67c96bca12f27ba5c17a76acdcb8b45834"
+checksum = "fed1b13e2000bd8e238d97a97de6fc30224f89a08b0aa5aaa09ed1bd68ba2fa1"
 dependencies = [
  "once_cell",
 ]
@@ -1896,9 +1896,9 @@ dependencies = [
 
 [[package]]
 name = "termimad"
-version = "0.20.6"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfab44b4bc17601cf226cce31c87462a4a5bd5d325948c8ebbc9e715660a1287"
+checksum = "d86d19aafb932e65acc333b49cb0bd7d9c650a94fe3f2550ce91aea00f582a86"
 dependencies = [
  "coolor",
  "crossbeam",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ git-repository = "0.30.2"
 lazy-regex = "2.3.1"
 notify = "5.0.0"
 serde = { version = "1.0.136", features = ["derive"] }
-termimad = "0.20.6"
+termimad = "0.21.0"
 tokio = { version = "1.17.0", default-features = false, features = ["net", "sync", "process", "rt", "macros", "io-util"] }
 toml = "0.5.8"
 unicode-width = "0.1.10"

--- a/src/args.rs
+++ b/src/args.rs
@@ -45,7 +45,7 @@ pub struct Args {
     #[clap(short = 'l', long = "list-jobs")]
     pub list_jobs: bool,
 
-    /// don't access the network (jobs must use it, though)
+    /// don't access the network (jobs may use it, though)
     #[clap(long = "offline")]
     pub offline: bool,
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -45,6 +45,10 @@ pub struct Args {
     #[clap(short = 'l', long = "list-jobs")]
     pub list_jobs: bool,
 
+    /// don't access the network (jobs must use it, though)
+    #[clap(long = "offline")]
+    pub offline: bool,
+
     /// create a bacon.toml file, ready to be customized
     #[clap(long = "init")]
     pub init: bool,


### PR DESCRIPTION
The `--offline` launch argument of bacon prevents it from accessing the network (it doesn't prevent jobs from using it, though).

A downside of using this option is a potentially less relevant selection of files to watch.