### PR TITLE
remove keybindings from default bacon.toml

### DIFF
--- a/bacon.toml
+++ b/bacon.toml
@@ -65,10 +65,5 @@ command = ["cargo", "check", "--target", "x86_64-pc-windows-gnu", "--color", "al
 # Shortcuts to internal functions (scrolling, toggling, etc.)
 # should go in your personal prefs.toml file instead.
 [keybindings]
-a = "job:check-all"
-i = "job:initial"
-d = "job:doc-open"
-t = "job:test"
-r = "job:run"
 alt-w = "job:check-win"
 shift-d = "scroll-lines(5)"

--- a/defaults/default-bacon.toml
+++ b/defaults/default-bacon.toml
@@ -49,11 +49,6 @@ allow_warnings = true
 # You may define here keybindings that would be specific to
 # a project, for example a shortcut to launch a specific job.
 # Shortcuts to internal functions (scrolling, toggling, etc.)
-# should go in your personal prefs.toml file instead.
+# should go in your personal global prefs.toml file instead.
 [keybindings]
-a = "job:check-all"
-i = "job:initial"
-c = "job:clippy"
-d = "job:doc-open"
-t = "job:test"
-r = "job:run"
+# alt-m = "job:my-job"

--- a/defaults/default-prefs.toml
+++ b/defaults/default-prefs.toml
@@ -25,7 +25,8 @@
 # export_locations = true
 
 # Uncomment and change the key-bindings you want to define
-# (some of those ones are the defaults)
+# (some of those ones are the defaults and are just here
+#  for illustration)
 [keybindings]
 # esc = "back"
 # ctrl-c = "quit"
@@ -46,3 +47,9 @@
 # shift-g = "scroll-to-bottom"
 # k = "scroll-lines(-1)"
 # j = "scroll-lines(1)"
+# a = "job:check-all"
+# i = "job:initial"
+# c = "job:clippy"
+# d = "job:doc-open"
+# t = "job:test"
+# r = "job:run"

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -40,6 +40,13 @@ impl Default for KeyBindings {
         bindings.set(key!(Space), Internal::Scroll(ScrollCommand::Pages(1)));
         bindings.set(key!(esc), Internal::Back);
         bindings.set(key!(ctrl - d), JobRef::Default);
+        bindings.set(key!(i), JobRef::Initial);
+        // keybindings for some common jobs
+        bindings.set(key!(a), JobRef::from_job_name("check-all"));
+        bindings.set(key!(c), JobRef::from_job_name("clippy"));
+        bindings.set(key!(d), JobRef::from_job_name("doc-open"));
+        bindings.set(key!(t), JobRef::from_job_name("test"));
+        bindings.set(key!(r), JobRef::from_job_name("run"));
         bindings
     }
 }

--- a/src/mission_location.rs
+++ b/src/mission_location.rs
@@ -49,9 +49,7 @@ impl MissionLocation {
                 .other_options(["--frozen".to_string(), "--offline".to_string()])
                 .exec()
         } else {
-            MetadataCommand::new()
-                .current_dir(&intended_dir)
-                .exec()
+            MetadataCommand::new().current_dir(&intended_dir).exec()
         };
         let metadata = match metadata {
             Ok(m) => m,


### PR DESCRIPTION
When no bacon.toml file was defined, the default one was used and its keybindings were overrinding the
personal global ones

Fix #116