### PR TITLE
Use different CSI codes depending on the platform

### DIFF
--- a/src/tty.rs
+++ b/src/tty.rs
@@ -10,11 +10,26 @@ use {
 
 pub const CSI_RESET: &str = "\u{1b}[0m\u{1b}[0m";
 pub const CSI_BOLD: &str = "\u{1b}[1m";
+pub const CSI_ITALIC: &str = "\u{1b}[3m";
+
 pub const CSI_BOLD_RED: &str = "\u{1b}[1m\u{1b}[38;5;9m";
 pub const CSI_BOLD_ORANGE: &str = "\u{1b}[1m\u{1b}[38;5;208m";
+
+#[cfg(windows)]
+pub const CSI_BOLD_YELLOW: &str = "\u{1b}[1m\u{1b}[38;5;11m";
+#[cfg(not(windows))]
 pub const CSI_BOLD_YELLOW: &str = "\u{1b}[1m\u{1b}[33m";
+
+#[cfg(windows)]
+pub const CSI_BOLD_BLUE: &str = "\u{1b}[1m\u{1b}[38;5;14m";
+#[cfg(not(windows))]
 pub const CSI_BOLD_BLUE: &str = "\u{1b}[1m\u{1b}[38;5;12m";
-pub const CSI_ITALIC: &str = "\u{1b}[3m";
+
+#[cfg(windows)]
+pub const CSI_BOLD_4BIT_YELLOW: &str = "\u{1b}[1m\u{1b}[33m";
+
+#[cfg(windows)]
+pub const CSI_BOLD_WHITE: &str = "\u{1b}[1m\u{1b}[38;5;15m";
 
 static TAB_REPLACEMENT: &str = "    ";
 


### PR DESCRIPTION
Hello!

This fixes #70 

I do not know why, but on Windows, other CSI codes appears in the 'lines', so LineAnalysis returns garbage. 
This fix changes some CSI codes in tty, and also slightly changes the conditions by which the line type is determined in LineAnalysis on Windows