### PR TITLE
add tests, benches and examples to default watches

### DIFF
--- a/defaults/default-bacon.toml
+++ b/defaults/default-bacon.toml
@@ -12,17 +12,14 @@ need_stdout = false
 [jobs.check-all]
 command = ["cargo", "check", "--all-targets", "--color", "always"]
 need_stdout = false
-watch = ["tests", "benches", "examples"]
 
 [jobs.clippy]
 command = ["cargo", "clippy", "--all-targets", "--color", "always"]
 need_stdout = false
-watch = ["tests", "benches", "examples"]
 
 [jobs.test]
 command = ["cargo", "test", "--color", "always"]
 need_stdout = true
-watch = ["tests"]
 
 [jobs.doc]
 command = ["cargo", "doc", "--color", "always", "--no-deps"]
@@ -45,7 +42,6 @@ on_success = "back" # so that we don't open the browser at each change
 command = [ "cargo", "run", "--color", "always" ]
 need_stdout = true
 allow_warnings = true
-watch = ["examples"]
 
 # You may define here keybindings that would be specific to
 # a project, for example a shortcut to launch a specific job.

--- a/src/mission.rs
+++ b/src/mission.rs
@@ -8,11 +8,12 @@ use {
     },
     std::{
         collections::HashSet,
-        iter,
         path::PathBuf,
         process::Command,
     },
 };
+
+static DEFAULT_WATCHES: &[&str] = &["src", "tests", "benches", "examples"];
 
 /// the description of the mission of bacon
 /// after analysis of the args, env, and surroundings
@@ -49,9 +50,14 @@ impl<'s> Mission<'s> {
                     .parent()
                     .expect("parent of a target folder is a root folder");
                 if add_all_src {
-                    let src_watch_iter = iter::once("src");
-                    let other_watch_iter = job.watch.iter().map(String::as_ref);
-                    for dir in src_watch_iter.chain(other_watch_iter) {
+                    let mut watches: Vec<&str> = job.watch.iter().map(|s| s.as_str()).collect();
+                    for watch in DEFAULT_WATCHES {
+                        if !watches.contains(watch) {
+                            watches.push(watch);
+                        }
+                    }
+                    debug!("watches: {watches:?}");
+                    for dir in &watches {
                         let full_path = item_path.join(dir);
                         if full_path.exists() {
                             directories_to_watch.push(full_path.into());


### PR DESCRIPTION
By default, "src", "tests", "benches", "examples" are now watched.

Fix #119