### PR TITLE
default_watch job parameter

### DIFF
--- a/src/job.rs
+++ b/src/job.rs
@@ -12,9 +12,19 @@ pub struct Job {
     /// by the PackageConfig::from_path loader
     pub command: Vec<String>,
 
+    /// Whether to apply the default watch list, which is
+    /// `["src", "tests", "benches", "examples"]`
+    ///
+    /// This is true by default. Set it to false if you want
+    /// to watch nothing, or only the directories you set in
+    /// `watch`.
+    #[serde(default = "default_true")]
+    pub default_watch: bool,
+
     /// A list of directories that will be watched if the job
     /// is run on a package.
-    /// src is implicitly included.
+    /// src, examples, tests, and benches are implicitly included
+    /// unless you `set default_watch` to false.
     #[serde(default)]
     pub watch: Vec<String>,
 
@@ -45,6 +55,11 @@ pub struct Job {
 
 static DEFAULT_ARGS: &[&str] = &["--color", "always"];
 
+// waiting for https://github.com/serde-rs/serde/issues/368
+fn default_true() -> bool {
+    true
+}
+
 impl Job {
     /// Builds a `Job` for a cargo alias
     pub fn from_alias(
@@ -63,6 +78,7 @@ impl Job {
         }
         Self {
             command,
+            default_watch: true,
             watch: Vec::new(),
             need_stdout: false,
             on_success: None,

--- a/src/mission.rs
+++ b/src/mission.rs
@@ -51,9 +51,11 @@ impl<'s> Mission<'s> {
                     .expect("parent of a target folder is a root folder");
                 if add_all_src {
                     let mut watches: Vec<&str> = job.watch.iter().map(|s| s.as_str()).collect();
-                    for watch in DEFAULT_WATCHES {
-                        if !watches.contains(watch) {
-                            watches.push(watch);
+                    if job.default_watch {
+                        for watch in DEFAULT_WATCHES {
+                            if !watches.contains(watch) {
+                                watches.push(watch);
+                            }
                         }
                     }
                     debug!("watches: {watches:?}");

--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -85,13 +85,14 @@ It's defined by the following fields:
 
 field | optional | meaning
 :-|:-:|:-
-command | no | The tokens making the command to execute (first one is the executable)
-watch | yes | A list of directories that will be watched if the job is run on a package. `src` is implicitly included.
+command | no | the tokens making the command to execute (first one is the executable)
+watch | yes | a list of directories that will be watched if the job is run on a package. `src`, `tests`, `examples`, and `benches` are implicitly included unles `default_watch` is set to false
+default_watch | yes | whether to watch default directories (`src`, `tests`, `examples`, and `benches`). `true` by default. When it's set to `false`, only the directories in `watch` are watched (none if `watch` is empty or not supplied)
 need_stdout | yes |whether we need to capture stdout too (stderr is always captured). Default is `false`
 on_success | yes | the action to run when there's no error, warning or test failures
-allow_warnings | yes | if true, the action is considered a success even when there are warnings. Default is `false` but the standard `run` job is configured with `allow_warnings=false`
-allow_failures | yes | if true, the action is considered a success even when there are test failures. Default is `false`
-apply_gitignore | yes | if true (which is default) the job isn't triggered when the modified file is excluded by gitignore rules
+allow_warnings | yes | if `true`, the action is considered a success even when there are warnings. Default is `false` but the standard `run` job is configured with `allow_warnings=false`
+allow_failures | yes | if `true`, the action is considered a success even when there are test failures. Default is `false`
+apply_gitignore | yes | if `true` (which is default) the job isn't triggered when the modified file is excluded by gitignore rules
 
 Example:
 
@@ -171,4 +172,4 @@ job reference | meaning
 -|-
 `job:default` | the job defined as *default* in the bacon.toml file
 `job:initial` | the job specified as argument, or the default one if there was none explicit
-`job:previous` | the job which ran before, if any (or we would quit). The `back` action has usually the same effect
+`job:previous` | the job which ran before, if any (or we would quit). The `back` internal has usually the same effect


### PR DESCRIPTION
Add a job parameter disabling the default watch list. Purpose is either to watch only some directories, or to watch nothing (i.e. have the job only manually triggered)

Fix #92