### PR TITLE
parse more largely from stdout and not jus stderr

### DIFF
--- a/src/command_result.rs
+++ b/src/command_result.rs
@@ -25,6 +25,7 @@ impl CommandResult {
         let lines = &output.lines;
         let error_code = exit_status.and_then(|s| s.code()).filter(|&c| c != 0);
         let mut report = Report::from_lines(lines)?;
+        debug!("report stats: {:?}", &report.stats);
         if let Some(error_code) = error_code {
             if report.stats.errors + report.stats.test_fails == 0 {
                 // report shows no error while the command exe reported

--- a/src/tty.rs
+++ b/src/tty.rs
@@ -12,6 +12,9 @@ pub const CSI_RESET: &str = "\u{1b}[0m\u{1b}[0m";
 pub const CSI_BOLD: &str = "\u{1b}[1m";
 pub const CSI_ITALIC: &str = "\u{1b}[3m";
 
+pub const CSI_GREEN: &str = "\u{1b}[32m";
+
+pub const CSI_RED: &str = "\u{1b}[31m";
 pub const CSI_BOLD_RED: &str = "\u{1b}[1m\u{1b}[38;5;9m";
 pub const CSI_BOLD_ORANGE: &str = "\u{1b}[1m\u{1b}[38;5;208m";
 
@@ -246,6 +249,11 @@ impl TLine {
         } else {
             None
         }
+    }
+    pub fn has(&self, part: &str) -> bool {
+        self.strings
+            .iter()
+            .any(|s| s.raw.contains(part))
     }
 }
 


### PR DESCRIPTION
Due to #124 especially, we're more likely to receive test failure abstracts on stdout and not just stderr.

With this PR, lines from stdout are better parsed.

Fix #137 