### PR TITLE
allow defining env vars for job execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## next
+- allow defining env vars for jobs - Fix #145
+
 <a name="v2.10.0"></a>
 ### v2.10.0 - 2023/06/27
 - accept bacon.toml file at workspace level - Fix #141

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bacon"
-version = "2.10.0"
+version = "2.11.0-dev"
 authors = ["dystroy <denys.seguret@gmail.com>"]
 repository = "https://github.com/Canop/bacon"
 description = "background rust compiler"

--- a/src/job.rs
+++ b/src/job.rs
@@ -1,6 +1,7 @@
 use {
     crate::*,
     serde::Deserialize,
+    std::collections::HashMap,
 };
 
 /// One of the possible job that bacon can run
@@ -49,8 +50,12 @@ pub struct Job {
     #[serde(default)]
     pub allow_failures: bool,
 
-    /// Thether gitignore rules must be applied
+    /// Whether gitignore rules must be applied
     pub apply_gitignore: Option<bool>,
+
+    /// Env vars to set for this job execution
+    #[serde(default)]
+    pub env: HashMap<String, String>,
 }
 
 static DEFAULT_ARGS: &[&str] = &["--color", "always"];
@@ -61,7 +66,7 @@ fn default_true() -> bool {
 }
 
 impl Job {
-    /// Builds a `Job` for a cargo alias
+    /// Build a `Job` for a cargo alias
     pub fn from_alias(
         alias_name: &str,
         settings: &Settings,
@@ -85,6 +90,7 @@ impl Job {
             allow_warnings: false,
             allow_failures: false,
             apply_gitignore: None,
+            env: Default::default(),
         }
     }
 }

--- a/src/mission.rs
+++ b/src/mission.rs
@@ -215,6 +215,7 @@ impl<'s> Mission<'s> {
             }
         }
         command.current_dir(&self.cargo_execution_directory);
+        command.envs(&self.job.env);
         debug!("command: {:#?}", &command);
         command
     }

--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -93,6 +93,7 @@ on_success | yes | the action to run when there's no error, warning or test fail
 allow_warnings | yes | if `true`, the action is considered a success even when there are warnings. Default is `false` but the standard `run` job is configured with `allow_warnings=false`
 allow_failures | yes | if `true`, the action is considered a success even when there are test failures. Default is `false`
 apply_gitignore | yes | if `true` (which is default) the job isn't triggered when the modified file is excluded by gitignore rules
+env | yes | a map of environment vars, for example `env.LOG_LEVEL="die"`
 
 Example:
 


### PR DESCRIPTION
Fix #145

Example:

```
[jobs.c]
command = [
    "cargo", "run",
    "--color", "always",
]
need_stdout = true
allow_warnings = true
env.LOG_LEVEL="Carotte"
env.Bourasque="CPRC"
```
