### PR TITLE
add a "refresh" internal and bind it to F5

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -150,9 +150,17 @@ pub fn run(
                     Internal::Quit => {
                         break;
                     }
+                    Internal::Refresh => {
+                        if let Err(e) = executor.start(state.new_task()) {
+                            debug!("error sending task on rerun: {}", e);
+                        } else {
+                            state.clear();
+                            state.computation_starts();
+                        }
+                    }
                     Internal::ReRun => {
                         if let Err(e) = executor.start(state.new_task()) {
-                            debug!("error sending task on re-rerun: {}", e);
+                            debug!("error sending task on refresh: {}", e);
                         } else {
                             state.computation_starts();
                         }

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -10,6 +10,7 @@ pub enum Internal {
     Back,
     Help,
     Quit,
+    Refresh, // clear and rerun
     ReRun,
     Scroll(ScrollCommand),
     ToggleBacktrace,
@@ -27,6 +28,7 @@ impl fmt::Display for Internal {
             Self::Back => write!(f, "back to previous page or job"),
             Self::Help => write!(f, "help"),
             Self::Quit => write!(f, "quit"),
+            Self::Refresh => write!(f, "clear then run current job again"),
             Self::ReRun => write!(f, "run current job again"),
             Self::Scroll(scroll_command) => scroll_command.fmt(f),
             Self::ToggleBacktrace => write!(f, "toggle backtrace"),
@@ -47,6 +49,7 @@ impl std::str::FromStr for Internal {
             "back" => Ok(Self::Back),
             "help" => Ok(Self::Help),
             "quit" => Ok(Self::Quit),
+            "refresh" => Ok(Self::Refresh),
             "rerun" => Ok(Self::ReRun),
             "toggle-raw-output" => Ok(Self::ToggleRawOutput),
             "toggle-backtrace" => Ok(Self::ToggleBacktrace),

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -27,7 +27,7 @@ impl Default for KeyBindings {
         bindings.set(key!(ctrl - c), Internal::Quit);
         bindings.set(key!(ctrl - q), Internal::Quit);
         bindings.set(key!(q), Internal::Quit);
-        bindings.set(key!(F5), Internal::ReRun);
+        bindings.set(key!(F5), Internal::Refresh);
         bindings.set(key!(s), Internal::ToggleSummary);
         bindings.set(key!(w), Internal::ToggleWrap);
         bindings.set(key!(b), Internal::ToggleBacktrace);

--- a/src/state.rs
+++ b/src/state.rs
@@ -184,6 +184,10 @@ impl<'s> AppState<'s> {
             self.update_wrap(self.width - 1);
         }
     }
+    pub fn clear(&mut self) {
+        self.take_output();
+        self.cmd_result = CommandResult::None;
+    }
     pub fn computation_starts(&mut self) {
         self.computing = true;
     }


### PR DESCRIPTION
It clears the output then run the current job again.

This is useful for example when there's a long or never-ending job and you want to get the new output before it's finished.

See https://github.com/Canop/bacon/issues/159