### PR TITLE
fix offset on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### next
 - insert features related arguments before the -- when there's some - Fix #171
+- fix offset in Windows terminal - Fix #175
 
 <a name="v2.14.2"></a>
 ### v2.14.2 - 2024/02/10

--- a/bacon.toml
+++ b/bacon.toml
@@ -18,6 +18,14 @@ command = [
 need_stdout = false
 watch = ["benches"]
 
+
+[jobs.win]
+command = [
+	"cross", "build",
+	"--target", "x86_64-pc-windows-gnu",
+]
+
+
 [jobs.test]
 command = [
     "cargo", "test", "--color", "always",

--- a/src/app.rs
+++ b/src/app.rs
@@ -74,13 +74,6 @@ pub fn run(
             recv(user_events) -> user_event => {
                 match user_event?.event {
                     Event::Resize(mut width, mut height) => {
-                        // I don't know why but Crossterm seems to always report an
-                        // understimated size on Windows
-                        #[cfg(windows)]
-                        {
-                            width += 1;
-                            height += 1;
-                        }
                         state.resize(width, height);
                     }
                     Event::Key(key_event) => {


### PR DESCRIPTION
With Termimad 0.29 came a new version of Crossterm which seems to have fixed a very old size/windows related bug.

Fix #175