### PR TITLE
Add option to disable help line

### DIFF
--- a/defaults/default-prefs.toml
+++ b/defaults/default-prefs.toml
@@ -16,6 +16,11 @@
 #
 # reverse = true
 
+# Uncomment and change the value (true/false) to
+# specify whether bacon should show a help line.
+#
+# help_line = false
+
 # Exporting "locations" lets you use them in an external
 # tool, for example as a list of jump locations in an IDE.
 #

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,7 +1,13 @@
 use {
     crate::*,
-    anyhow::{bail, Result},
-    clap::{CommandFactory, Parser},
+    anyhow::{
+        bail,
+        Result,
+    },
+    clap::{
+        CommandFactory,
+        Parser,
+    },
     termimad::ansi,
 };
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,13 +1,7 @@
 use {
     crate::*,
-    anyhow::{
-        bail,
-        Result,
-    },
-    clap::{
-        CommandFactory,
-        Parser,
-    },
+    anyhow::{bail, Result},
+    clap::{CommandFactory, Parser},
     termimad::ansi,
 };
 
@@ -67,6 +61,14 @@ pub struct Args {
     /// Start with standard gui order
     #[clap(long)]
     pub no_reverse: bool,
+
+    /// Display a help line
+    #[clap(long)]
+    pub help_line: bool,
+
+    /// Do not display a help line
+    #[clap(long)]
+    pub no_help_line: bool,
 
     /// List available jobs
     #[clap(short = 'l', long)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,7 +3,11 @@ use {
     anyhow::*,
     lazy_regex::regex_is_match,
     serde::Deserialize,
-    std::{collections::HashMap, fs, path::Path},
+    std::{
+        collections::HashMap,
+        fs,
+        path::Path,
+    },
 };
 
 /// A configuration item which may be stored either as `bacon.toml`

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,11 +3,7 @@ use {
     anyhow::*,
     lazy_regex::regex_is_match,
     serde::Deserialize,
-    std::{
-        collections::HashMap,
-        fs,
-        path::Path,
-    },
+    std::{collections::HashMap, fs, path::Path},
 };
 
 /// A configuration item which may be stored either as `bacon.toml`
@@ -20,6 +16,7 @@ pub struct Config {
     pub summary: Option<bool>,
     pub wrap: Option<bool>,
     pub reverse: Option<bool>,
+    pub help_line: Option<bool>,
     #[deprecated(since = "2.0.0", note = "use keybindings")]
     pub vim_keys: Option<bool>,
     #[deprecated(since = "2.9.0", note = "use export.enabled")]

--- a/src/examples.rs
+++ b/src/examples.rs
@@ -34,4 +34,3 @@ pub static EXAMPLES: &[Example] = &[
         cmd: "bacon -s",
     },
 ];
-

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,8 +1,4 @@
-use {
-    crate::*,
-    anyhow::*,
-    std::collections::HashMap,
-};
+use {crate::*, anyhow::*, std::collections::HashMap};
 
 /// The settings used in the application.
 ///
@@ -20,6 +16,7 @@ pub struct Settings {
     pub summary: bool,
     pub wrap: bool,
     pub reverse: bool,
+    pub help_line: bool,
     pub no_default_features: bool,
     pub all_features: bool,
     pub features: Option<String>, // comma separated list
@@ -38,6 +35,7 @@ impl Default for Settings {
             summary: false,
             wrap: true,
             reverse: false,
+            help_line: true,
             no_default_features: Default::default(),
             all_features: Default::default(),
             features: Default::default(),
@@ -64,6 +62,9 @@ impl Settings {
         }
         if let Some(b) = config.reverse {
             self.reverse = b;
+        }
+        if let Some(b) = config.help_line {
+            self.help_line = b;
         }
         #[allow(deprecated)] // for compatibility
         if let Some(b) = config.export_locations {
@@ -110,6 +111,12 @@ impl Settings {
         }
         if args.no_reverse {
             self.reverse = false;
+        }
+        if args.help_line {
+            self.help_line = true;
+        }
+        if args.no_help_line {
+            self.help_line = false;
         }
         if args.export_locations {
             self.export.enabled = true;

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,4 +1,8 @@
-use {crate::*, anyhow::*, std::collections::HashMap};
+use {
+    crate::*,
+    anyhow::*,
+    std::collections::HashMap,
+};
 
 /// The settings used in the application.
 ///

--- a/src/state.rs
+++ b/src/state.rs
@@ -4,11 +4,21 @@ use {
     std::io::Write,
     termimad::{
         crossterm::{
-            cursor, execute,
-            style::{Attribute, Color::*, Print},
+            cursor,
+            execute,
+            style::{
+                Attribute,
+                Color::*,
+                Print,
+            },
         },
-        minimad::{Alignment, Composite},
-        Area, CompoundStyle, MadSkin,
+        minimad::{
+            Alignment,
+            Composite,
+        },
+        Area,
+        CompoundStyle,
+        MadSkin,
     },
 };
 


### PR DESCRIPTION
Add an option to disable the help line.

This can either be done by using `--no-help-line` or modifying `prefs.toml`:

```
# .config/bacon/prefs.toml
help_line = false
```

The argument `--help-line` overwrites this setting.

The help line doesn't really serve a purpose for me, as it really doesn't show a lot of information and I didn't like it being constantly there. 