### PR TITLE
The default for the `run` job is `allow_warnings=true`

### DIFF
--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -98,7 +98,7 @@ watch | yes | a list of directories that will be watched if the job is run on a 
 default_watch | yes | whether to watch default directories (`src`, `tests`, `examples`, and `benches`). `true` by default. When it's set to `false`, only the directories in `watch` are watched (none if `watch` is empty or not supplied)
 need_stdout | yes |whether we need to capture stdout too (stderr is always captured). Default is `false`
 on_success | yes | the action to run when there's no error, warning or test failures
-allow_warnings | yes | if `true`, the action is considered a success even when there are warnings. Default is `false` but the standard `run` job is configured with `allow_warnings=false`
+allow_warnings | yes | if `true`, the action is considered a success even when there are warnings. Default is `false` but the standard `run` job is configured with `allow_warnings=true`
 allow_failures | yes | if `true`, the action is considered a success even when there are test failures. Default is `false`
 apply_gitignore | yes | if `true` (which is default) the job isn't triggered when the modified file is excluded by gitignore rules
 env | yes | a map of environment vars, for example `env.LOG_LEVEL="die"`


### PR DESCRIPTION
Just a small typo I found while reading the docs.