### PR TITLE
Parse test results from tests running with `--quiet`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - default binding for 'c' in bacon.toml is now the new 'clippy-all' job which does what the old 'clippy' job was doing. 'clippy' job changed to not run on all targets. Default bacon.toml explain how to bind 'c' to clippy instead of 'clippy-all' - Fix #167
 - expand env vars in job command unless the job specifies `expand_env_vars = false` - Fix #181
 - some file events filtered out from watch (feedback welcome, especially if you notice some failures to recompute)
+- parse test results even when tests are run with `-q`/`--quiet`
 
 <a name="v2.16.0"></a>
 ### v2.16.0 - 2024/03/30

--- a/src/line_analysis.rs
+++ b/src/line_analysis.rs
@@ -130,7 +130,7 @@ fn is_build_failed(ts: Option<&TString>) -> bool {
 /// part is in another TString)
 fn as_test_name(s: &str) -> Option<&str> {
     regex_captures!(
-        r#"^test\s+(.+?)(?: - should panic\s*)?(?: - compile\s*)?\s+...\s*$"#,
+        r#"^(?:test\s+)?(.+?)(?: - should panic\s*)?(?: - compile\s*)?\s+...\s*$"#,
         s
     )
     .map(|(_, key)| key)
@@ -154,7 +154,7 @@ fn as_test_name(s: &str) -> Option<&str> {
 /// (in this case, the " - should panic" part isn't in the key, see #95)
 fn as_test_result(s: &str) -> Option<(&str, bool)> {
     regex_captures!(
-        r#"^test\s+(.+?)(?: - should panic\s*)?(?: - compile\s*)?\s+...\s+(\w+)$"#,
+        r#"^(?:test\s+)?(.+?)(?: - should panic\s*)?(?: - compile\s*)?\s+...\s+(\w+)$"#,
         s
     )
     .and_then(|(_, key, outcome)| match outcome {


### PR DESCRIPTION
Running tests with `-q`/`--quiet` outputs a `.` per test instead of the test name. When a test fails, the test name and `FAILED` is still printed, but the `test ` at the beginning of the line is omitted:
```
# run without `--quiet`
test tests::failing_test ... FAILED
# run with `--quiet`
tests::failing_test --- FAILED
```
This PR changes the regex used to parse the output to parse both output formats.