### PR TITLE
feat: allow context to be stored in location export

### DIFF
--- a/defaults/default-prefs.toml
+++ b/defaults/default-prefs.toml
@@ -29,8 +29,15 @@
 # Set 'enabled' to true to have bacon always export locations
 # This is equivalent to always adding -e to bacon commands
 # but can still be cancelled on specific launches with -E
+#
+# 'add_context_to_message' is used to control whether to ad
+# any normal line linked to the diagnostic title. When this 
+# is on, carriage returns are escaped to ensure we generate
+# everything on a single line. They can be expande by replacing
+# '\\n' with '\n' when read from the export locations file.
 [export]
 enabled = false
+add_context_to_message = false
 path = ".bacon-locations"
 line_format = "{kind} {path}:{line}:{column} {message}"
 

--- a/src/export_config.rs
+++ b/src/export_config.rs
@@ -10,4 +10,5 @@ pub struct ExportConfig {
     pub enabled: Option<bool>,
     pub path: Option<PathBuf>,
     pub line_format: Option<String>,
+    pub add_context_to_message: Option<bool>
 }

--- a/src/export_settings.rs
+++ b/src/export_settings.rs
@@ -9,6 +9,7 @@ pub struct ExportSettings {
     pub enabled: bool,
     pub path: PathBuf,
     pub line_format: String,
+    pub add_context_to_message: bool
 }
 
 impl Default for ExportSettings {
@@ -17,6 +18,7 @@ impl Default for ExportSettings {
             enabled: false,
             path: default_path(),
             line_format: default_line_format().to_string(),
+            add_context_to_message: false
         }
     }
 }
@@ -44,6 +46,9 @@ impl ExportSettings {
         }
         if let Some(line_format) = &config.line_format {
             self.line_format.clone_from(line_format);
+        }
+        if let Some(add_context_to_message) = config.add_context_to_message {
+            self.add_context_to_message = add_context_to_message;
         }
     }
 }

--- a/src/line.rs
+++ b/src/line.rs
@@ -30,6 +30,22 @@ impl Line {
             _ => None,
         }
     }
+
+    /// If the line is normal. get its messages
+    pub fn context(&self) -> Option<String> {
+        match self.line_type {
+            LineType::Normal => Some(
+                self.content
+                    .strings
+                    .iter()
+                    .map(|ts| ts.raw.as_str())
+                    .collect::<Vec<&str>>()
+                    .join(""),
+            ),
+            _ => None,
+        }
+    }
+
     /// Return the location as given by cargo
     /// It's usually relative and may contain the line and column
     pub fn location(&self) -> Option<&str> {


### PR DESCRIPTION
I have created a LSP server based on Bacon (great software btw) called [bacon-ls](https://github.com/crisidev/bacon-ls) ([blog post](https://lmno.lol/crisidev/bacon-language-server)) that makes use of the location export.

This PR allows a new setting called `add_context_to_message` changing the line export to include all the context from the compiler.