### PR TITLE
feat: allow context to be stored in location export

### DIFF
--- a/defaults/default-prefs.toml
+++ b/defaults/default-prefs.toml
@@ -29,8 +29,15 @@
 # Set 'enabled' to true to have bacon always export locations
 # This is equivalent to always adding -e to bacon commands
 # but can still be cancelled on specific launches with -E
+#
+# 'add_context_to_message' is used to control whether to ad
+# any normal line linked to the diagnostic title. When this 
+# is on, carriage returns are escaped to ensure we generate
+# everything on a single line. They can be expande by replacing
+# '\\n' with '\n' when read from the export locations file.
 [export]
 enabled = false
+add_context_to_message = false
 path = ".bacon-locations"
 line_format = "{kind} {path}:{line}:{column} {message}"
 

--- a/defaults/default-prefs.toml
+++ b/defaults/default-prefs.toml
@@ -22,22 +22,24 @@
 # help_line = false
 
 # Exporting "locations" lets you use them in an external
-# tool, for example as a list of jump locations in an IDE.
+# tool, for example as a list of jump locations in an IDE
+# or in a language server.
 #
 # See https://dystroy.org/bacon/config/#export-locations
 #
 # Set 'enabled' to true to have bacon always export locations
 # This is equivalent to always adding -e to bacon commands
-# but can still be cancelled on specific launches with -E
+# but can still be canceled on specific launches with -E
 #
-# 'add_context_to_message' is used to control whether to ad
-# any normal line linked to the diagnostic title. When this 
-# is on, carriage returns are escaped to ensure we generate
-# everything on a single line. They can be expande by replacing
-# '\\n' with '\n' when read from the export locations file.
+# Possible line_format parts:
+#  - kind: warning|error|test 
+#  - path: complete absolute path to the file
+#  - line: 1-based line number
+#  - column: 1-based column
+#  - message: description of the item
+#  - context: unstyled lines of output, separated with escaped newlines (`\\n`)
 [export]
 enabled = false
-add_context_to_message = false
 path = ".bacon-locations"
 line_format = "{kind} {path}:{line}:{column} {message}"
 

--- a/src/export_config.rs
+++ b/src/export_config.rs
@@ -10,4 +10,5 @@ pub struct ExportConfig {
     pub enabled: Option<bool>,
     pub path: Option<PathBuf>,
     pub line_format: Option<String>,
+    pub add_context_to_message: Option<bool>
 }

--- a/src/export_settings.rs
+++ b/src/export_settings.rs
@@ -9,6 +9,7 @@ pub struct ExportSettings {
     pub enabled: bool,
     pub path: PathBuf,
     pub line_format: String,
+    pub add_context_to_message: bool
 }
 
 impl Default for ExportSettings {
@@ -17,6 +18,7 @@ impl Default for ExportSettings {
             enabled: false,
             path: default_path(),
             line_format: default_line_format().to_string(),
+            add_context_to_message: false
         }
     }
 }
@@ -44,6 +46,9 @@ impl ExportSettings {
         }
         if let Some(line_format) = &config.line_format {
             self.line_format.clone_from(line_format);
+        }
+        if let Some(add_context_to_message) = config.add_context_to_message {
+            self.add_context_to_message = add_context_to_message;
         }
     }
 }

--- a/src/line.rs
+++ b/src/line.rs
@@ -30,6 +30,22 @@ impl Line {
             _ => None,
         }
     }
+
+    /// If the line is normal. get its messages
+    pub fn context(&self) -> Option<String> {
+        match self.line_type {
+            LineType::Normal => Some(
+                self.content
+                    .strings
+                    .iter()
+                    .map(|ts| ts.raw.as_str())
+                    .collect::<Vec<&str>>()
+                    .join(""),
+            ),
+            _ => None,
+        }
+    }
+
     /// Return the location as given by cargo
     /// It's usually relative and may contain the line and column
     pub fn location(&self) -> Option<&str> {

--- a/src/line.rs
+++ b/src/line.rs
@@ -31,21 +31,6 @@ impl Line {
         }
     }
 
-    /// If the line is normal. get its messages
-    pub fn context(&self) -> Option<String> {
-        match self.line_type {
-            LineType::Normal => Some(
-                self.content
-                    .strings
-                    .iter()
-                    .map(|ts| ts.raw.as_str())
-                    .collect::<Vec<&str>>()
-                    .join(""),
-            ),
-            _ => None,
-        }
-    }
-
     /// Return the location as given by cargo
     /// It's usually relative and may contain the line and column
     pub fn location(&self) -> Option<&str> {

--- a/src/tty.rs
+++ b/src/tty.rs
@@ -174,6 +174,13 @@ impl TLine {
             }],
         }
     }
+    pub fn to_raw(&self) -> String {
+        let mut s = String::new();
+        for ts in &self.strings {
+            s.push_str(&ts.raw);
+        }
+        s
+    }
     pub fn bold(raw: String) -> Self {
         Self {
             strings: vec![TString {


### PR DESCRIPTION
It's now possible to add `{context}` to the `export` / `line_format` settings, which is useful for  [bacon-ls](https://github.com/crisidev/bacon-ls).