### PR TITLE
added option `extraneous_args`

### DIFF
--- a/src/job.rs
+++ b/src/job.rs
@@ -69,6 +69,12 @@ pub struct Job {
     /// unless you `set default_watch` to false.
     #[serde(default)]
     pub watch: Vec<String>,
+
+    // Whether to insert extraneous arguments provided by bacon or end users
+    //
+    // Eg: --all-features or anything after -- in bacon incantation
+    #[serde(default = "default_true")]
+    pub extraneous_args: bool,
 }
 
 static DEFAULT_ARGS: &[&str] = &["--color", "always"];
@@ -106,6 +112,7 @@ impl Job {
             apply_gitignore: None,
             env: Default::default(),
             background: true,
+            extraneous_args: true,
         }
     }
 }

--- a/src/mission.rs
+++ b/src/mission.rs
@@ -179,6 +179,18 @@ impl<'s> Mission<'s> {
         let mut command = Command::new(
             tokens.next().unwrap(), // implies a check in the job
         );
+
+        if !self.job.extraneous_args {
+            for arg in tokens {
+                command.arg(arg);
+            }
+
+            command.current_dir(&self.cargo_execution_directory);
+            command.envs(&self.job.env);
+            debug!("command: {:#?}", &command);
+            return command
+        }
+
         let mut no_default_features_done = false;
         let mut features_done = false;
         let mut last_is_features = false;

--- a/src/mission.rs
+++ b/src/mission.rs
@@ -181,9 +181,7 @@ impl<'s> Mission<'s> {
         );
 
         if !self.job.extraneous_args {
-            for arg in tokens {
-                command.arg(arg);
-            }
+            command.args(tokens);
 
             command.current_dir(&self.cargo_execution_directory);
             command.envs(&self.job.env);

--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -103,6 +103,7 @@ allow_failures | yes | if `true`, the action is considered a success even when t
 apply_gitignore | yes | if `true` (which is default) the job isn't triggered when the modified file is excluded by gitignore rules
 env | yes | a map of environment vars, for example `env.LOG_LEVEL="die"`
 background | yes | compute in background and display only on end. Default is `true`
+extraneous_args | yes | if `false`, the action is run "as is" from `bacon.toml`, eg: no `--all-features` or `--features` inclusion. Default is `true`.
 
 Example:
 


### PR DESCRIPTION
I was annoyed at the inability to integrate `cargo fmt` as a bacon task easily alongside `--all-features` so I added an option `extraneous_args` which enables and disables functionality for modifying arguments in a `Job` during its conversion to a `Command`.