### PR TITLE
pause function

### DIFF
--- a/src/auto_refresh.rs
+++ b/src/auto_refresh.rs
@@ -1,0 +1,16 @@
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum AutoRefresh {
+    Paused,
+    PausedWithMisses,
+    Enabled,
+}
+
+impl AutoRefresh {
+    pub fn is_enabled(self) -> bool {
+        matches!(self, AutoRefresh::Enabled)
+    }
+
+    pub fn is_paused(self) -> bool {
+        matches!(self, AutoRefresh::Paused | AutoRefresh::PausedWithMisses)
+    }
+}

--- a/src/help_line.rs
+++ b/src/help_line.rs
@@ -8,6 +8,8 @@ pub struct HelpLine {
     toggle_backtrace: Option<String>,
     help: Option<String>,
     close_help: Option<String>,
+    pause: Option<String>,
+    unpause: Option<String>,
 }
 
 impl HelpLine {
@@ -36,6 +38,14 @@ impl HelpLine {
             .shortest_internal_key(Internal::Back)
             .or_else(|| kb.shortest_internal_key(Internal::Help))
             .map(|k| format!("*{k}* to close this help"));
+        let pause = kb
+            .shortest_internal_key(Internal::Pause)
+            .or(kb.shortest_internal_key(Internal::TogglePause))
+            .map(|k| format!("*{k}* to pause"));
+        let unpause = kb
+            .shortest_internal_key(Internal::Unpause)
+            .or(kb.shortest_internal_key(Internal::TogglePause))
+            .map(|k| format!("*{k}* to unpause"));
         Self {
             quit,
             toggle_summary,
@@ -44,6 +54,8 @@ impl HelpLine {
             toggle_backtrace,
             help,
             close_help,
+            pause,
+            unpause,
         }
     }
     pub fn markdown(
@@ -56,6 +68,11 @@ impl HelpLine {
                 parts.push(s);
             }
         } else {
+            if state.auto_refresh.is_paused() {
+                if let Some(s) = &self.unpause {
+                    parts.push(s);
+                }
+            }
             if let CommandResult::Report(report) = &state.cmd_result {
                 if report.suggest_backtrace {
                     if let Some(s) = &self.toggle_backtrace {
@@ -73,6 +90,11 @@ impl HelpLine {
                 }
             } else {
                 if let Some(s) = &self.wrap {
+                    parts.push(s);
+                }
+            }
+            if state.auto_refresh.is_enabled() {
+                if let Some(s) = &self.pause {
                     parts.push(s);
                 }
             }

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -17,6 +17,9 @@ pub enum Internal {
     ToggleRawOutput,
     ToggleSummary,
     ToggleWrap,
+    Pause,
+    Unpause,
+    TogglePause, // either pause or unpause
 }
 
 impl fmt::Display for Internal {
@@ -35,6 +38,9 @@ impl fmt::Display for Internal {
             Self::ToggleRawOutput => write!(f, "toggle raw output"),
             Self::ToggleSummary => write!(f, "toggle summary"),
             Self::ToggleWrap => write!(f, "toggle wrap"),
+            Self::Pause => write!(f, "pause"),
+            Self::Unpause => write!(f, "unpause"),
+            Self::TogglePause => write!(f, "toggle pause"),
         }
     }
 }
@@ -55,6 +61,9 @@ impl std::str::FromStr for Internal {
             "toggle-backtrace" => Ok(Self::ToggleBacktrace),
             "toggle-summary" => Ok(Self::ToggleSummary),
             "toggle-wrap" => Ok(Self::ToggleWrap),
+            "pause" => Ok(Self::Pause),
+            "unpause" => Ok(Self::Unpause),
+            "toggle pause" => Ok(Self::TogglePause),
             _ => Err(()),
         }
     }

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -41,6 +41,7 @@ impl Default for KeyBindings {
         bindings.set(key!(esc), Internal::Back);
         bindings.set(key!(ctrl - d), JobRef::Default);
         bindings.set(key!(i), JobRef::Initial);
+        bindings.set(key!(p), Internal::TogglePause);
         // keybindings for some common jobs
         bindings.set(key!(a), JobRef::from_job_name("check-all"));
         bindings.set(key!(c), JobRef::from_job_name("clippy"));

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod action;
 mod app;
 mod args;
+mod auto_refresh;
 mod cli;
 mod command_output;
 mod command_result;
@@ -39,6 +40,7 @@ mod wrapped_report;
 pub use {
     action::*,
     args::*,
+    auto_refresh::*,
     cli::*,
     command_output::*,
     command_result::*,

--- a/src/state.rs
+++ b/src/state.rs
@@ -61,6 +61,8 @@ pub struct AppState<'s> {
     help_page: Option<HelpPage>,
     /// display the raw output instead of the report
     raw_output: bool,
+    /// whether auto-refresh is enabled
+    pub auto_refresh: AutoRefresh,
 }
 
 impl<'s> AppState<'s> {
@@ -95,6 +97,7 @@ impl<'s> AppState<'s> {
             help_page: None,
             mission,
             raw_output: false,
+            auto_refresh: AutoRefresh::Enabled,
         })
     }
 

--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -167,6 +167,9 @@ scroll-lines(-1) | <kbd>↑</kbd> | move one line up
 scroll-lines(1) | <kbd>↓</kbd> | move one line down
 scroll-pages(-1) | <kbd>PageUp</kbd> | move one page up
 scroll-pages(1) | <kbd>PageDown</kbd> | move one page down
+pause |  | disable automatic job execution on change
+unpause |  | enable automatic job execution on change
+toggle pause | <kbd>p</kbd> | toggle pause
 
 The `scroll-lines` and `scroll-pages` internals are parameterized.
 You can for example define a shortcut to move down 5 lines:

--- a/website/docs/cookbook.md
+++ b/website/docs/cookbook.md
@@ -51,6 +51,12 @@ command = [
 need_stdout = false
 ```
 
+You may also add some modifiers on spot sessions, eg
+
+```bash
+bacon clippy -- -W clippy::pedantic
+```
+
 # Check for other platforms
 
 You may define specific jobs for specific targets:


### PR DESCRIPTION
Make it possible to pause refreshing.

Use case: review a big set of warnings, fixing maybe some, without triggering refreshes. For example when you launch `bacon clippy -- -W clippy::pedantic`.

Pausing and unpausing are by default bound to the 'p' key.

Fix #194 