### PR TITLE
Add kill command to job

### DIFF
--- a/defaults/default-bacon.toml
+++ b/defaults/default-bacon.toml
@@ -82,6 +82,7 @@ command = [
 need_stdout = true
 allow_warnings = true
 background = true
+# kill = ["kill", "-s", "TERM"]
 
 # This parameterized job runs the example of your choice, as soon
 # as the code compiles.

--- a/src/job.rs
+++ b/src/job.rs
@@ -36,6 +36,9 @@ pub struct Job {
     /// by the PackageConfig::from_path loader
     pub command: Vec<String>,
 
+    /// A kill command. If not provided, SIGKILL is used.
+    pub kill: Option<Vec<String>>,
+
     /// Whether to apply the default watch list, which is
     /// `["src", "tests", "benches", "examples"]`
     ///
@@ -102,6 +105,7 @@ impl Job {
         }
         Self {
             command,
+            kill: None,
             default_watch: true,
             expand_env_vars: true,
             watch: Vec::new(),

--- a/src/mission.rs
+++ b/src/mission.rs
@@ -271,6 +271,10 @@ impl<'s> Mission<'s> {
         command
     }
 
+    pub fn kill_command(&self) -> Vec<String> {
+        self.job.kill.clone().unwrap_or(Vec::new())
+    }
+
     /// whether we need stdout and not just stderr
     pub fn need_stdout(&self) -> bool {
         self.job.need_stdout


### PR DESCRIPTION
First, thanks for this awesome project!

This PR adds an optional job field `kill`, which specifies a custom command to be used for killing a job. It can be used to make sure that commands are given a chance to clean up when they are terminated by bacon.

If the `Command` API offered a better way to kill child processes, maybe killing them with SIGTERM could be the default. But as far as I can tell there is no easy portable way to do that without depending on some other crate. Letting the user specify a command for those cases where it is important that processes are killed cleanly seems a reasonable compromise. 