### PR TITLE
don't kill jobs on every change

### DIFF
--- a/defaults/default-prefs.toml
+++ b/defaults/default-prefs.toml
@@ -21,6 +21,10 @@
 #
 # help_line = false
 
+# Uncomment and change the value (true/false) to
+# set whether to display the count of changes since last job start
+# show_changes_count = false
+
 # Exporting "locations" lets you use them in an external
 # tool, for example as a list of jump locations in an IDE
 # or in a language server.

--- a/defaults/default-prefs.toml
+++ b/defaults/default-prefs.toml
@@ -23,7 +23,15 @@
 
 # Uncomment and change the value (true/false) to
 # set whether to display the count of changes since last job start
+#
 # show_changes_count = false
+
+# Uncomment one of those lines if you don't want the default
+# behavior triggered by a file change. This property can also
+# be set directly in a specific job.
+#
+# on_change_strategy = "kill_then_restart"
+# on_change_strategy = "wait_then_restart"
 
 # Exporting "locations" lets you use them in an external
 # tool, for example as a list of jump locations in an IDE

--- a/src/auto_refresh.rs
+++ b/src/auto_refresh.rs
@@ -2,9 +2,6 @@
 pub enum AutoRefresh {
     /// Don't rerun the job on file changes.
     Paused,
-    /// Don't rerun the job, also we already missed some changes
-    /// (so if we enable, we should immediately rerun the job).
-    PausedWithMisses,
     /// Run the job on file changes.
     Enabled,
 }
@@ -15,6 +12,6 @@ impl AutoRefresh {
     }
 
     pub fn is_paused(self) -> bool {
-        matches!(self, AutoRefresh::Paused | AutoRefresh::PausedWithMisses)
+        matches!(self, AutoRefresh::Paused)
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -32,6 +32,7 @@ pub struct Config {
     pub default_job: Option<ConcreteJobRef>,
     pub export: Option<ExportConfig>,
     pub show_changes_count: Option<bool>,
+    pub on_change_strategy: Option<OnChangeStrategy>,
 }
 
 impl Config {

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,6 +31,7 @@ pub struct Config {
     pub jobs: HashMap<String, Job>,
     pub default_job: Option<ConcreteJobRef>,
     pub export: Option<ExportConfig>,
+    pub show_changes_count: Option<bool>,
 }
 
 impl Config {

--- a/src/drawing.rs
+++ b/src/drawing.rs
@@ -15,6 +15,8 @@ pub fn goto(
     execute!(w, cursor::MoveTo(0, y))?;
     Ok(())
 }
+
+/// Clear from the current position to the end of the line
 pub fn clear_line(w: &mut W) -> Result<()> {
     execute!(w, terminal::Clear(terminal::ClearType::UntilNewLine))?;
     Ok(())

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -138,7 +138,7 @@ impl MissionExecutor {
                             Ok(_) => {
                                 let response = CommandExecInfo::Line(CommandOutputLine {
                                     content: TLine::from_tty(&line),
-                                    origin: CommandStream::StdErr,
+                                    origin: CommandStream::StdOut,
                                 });
                                 if sender.send(response).is_err() {
                                     break; // channel closed

--- a/src/job.rs
+++ b/src/job.rs
@@ -78,6 +78,11 @@ pub struct Job {
     // Eg: --all-features or anything after -- in bacon incantation
     #[serde(default = "default_true")]
     pub extraneous_args: bool,
+
+    /// How to handle changes: either immediately kill the current job
+    /// then restart it, or wait for the current job to finish before
+    /// restarting it.
+    pub on_change_strategy: Option<OnChangeStrategy>,
 }
 
 static DEFAULT_ARGS: &[&str] = &["--color", "always"];
@@ -117,6 +122,7 @@ impl Job {
             env: Default::default(),
             background: true,
             extraneous_args: true,
+            on_change_strategy: None,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,7 @@ mod line_type;
 mod list_jobs;
 mod mission;
 mod mission_location;
+mod on_change_strategy;
 mod report;
 mod scroll;
 mod settings;
@@ -66,6 +67,7 @@ pub use {
     list_jobs::*,
     mission::*,
     mission_location::*,
+    on_change_strategy::*,
     report::*,
     scroll::*,
     settings::*,

--- a/src/on_change_strategy.rs
+++ b/src/on_change_strategy.rs
@@ -1,0 +1,8 @@
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum OnChangeStrategy {
+    KillThenRestart,
+    WaitThenRestart,
+}

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -28,6 +28,7 @@ pub struct Settings {
     pub jobs: HashMap<String, Job>,
     pub default_job: ConcreteJobRef,
     pub export: ExportSettings,
+    pub show_changes_count: bool,
 }
 
 impl Default for Settings {
@@ -47,6 +48,7 @@ impl Default for Settings {
             jobs: Default::default(),
             default_job: Default::default(),
             export: Default::default(),
+            show_changes_count: false,
         }
     }
 }
@@ -93,6 +95,9 @@ impl Settings {
         }
         if let Some(export_config) = &config.export {
             self.export.apply_config(export_config);
+        }
+        if let Some(b) = config.show_changes_count {
+            self.show_changes_count = b;
         }
     }
     pub fn apply_args(

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -29,6 +29,7 @@ pub struct Settings {
     pub default_job: ConcreteJobRef,
     pub export: ExportSettings,
     pub show_changes_count: bool,
+    pub on_change_strategy: Option<OnChangeStrategy>,
 }
 
 impl Default for Settings {
@@ -49,6 +50,7 @@ impl Default for Settings {
             default_job: Default::default(),
             export: Default::default(),
             show_changes_count: false,
+            on_change_strategy: None,
         }
     }
 }
@@ -98,6 +100,9 @@ impl Settings {
         }
         if let Some(b) = config.show_changes_count {
             self.show_changes_count = b;
+        }
+        if let Some(b) = config.on_change_strategy {
+            self.on_change_strategy = Some(b);
         }
     }
     pub fn apply_args(

--- a/src/state.rs
+++ b/src/state.rs
@@ -430,7 +430,12 @@ impl<'s> AppState<'s> {
             ));
         }
         if self.show_changes_count {
-            t_line.add_badge(TString::num_badge(self.changes_since_last_job_start, "change", 235, 6));
+            t_line.add_badge(TString::num_badge(
+                self.changes_since_last_job_start,
+                "change",
+                235,
+                6,
+            ));
         }
         let width = self.width as usize;
         let cols = t_line.draw_in(w, width)?;

--- a/src/state.rs
+++ b/src/state.rs
@@ -94,6 +94,7 @@ impl<'s> AppState<'s> {
             wrap: mission.settings.wrap,
             backtrace: false,
             reverse: mission.settings.reverse,
+            show_changes_count: mission.settings.show_changes_count,
             status_skin,
             scroll: 0,
             top_item_idx: 0,
@@ -103,7 +104,6 @@ impl<'s> AppState<'s> {
             raw_output: false,
             auto_refresh: AutoRefresh::Enabled,
             changes_since_last_job_start: 0,
-            show_changes_count: true,
         })
     }
 

--- a/src/tty.rs
+++ b/src/tty.rs
@@ -73,8 +73,8 @@ impl TString {
         fg: u8,
         bg: u8,
     ) -> Self {
-        let raw = if num == 1 {
-            format!(" 1 {} ", cat)
+        let raw = if num < 2 {
+            format!(" {} {} ", num, cat)
         } else {
             format!(" {} {}s ", num, cat)
         };

--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -103,6 +103,7 @@ env | a map of environment vars, for example `env.LOG_LEVEL="die"` |
 kill | a command replacing the default job interruption (platform dependant, `SIGKILL` on unix). For example `kill = ["kill", "-s", "INT"]` |
 extraneous_args | if `false`, the action is run "as is" from `bacon.toml`, eg: no `--all-features` or `--features` inclusion | `true`
 need_stdout |whether we need to capture stdout too (stderr is always captured) | `false`
+on_change_strategy | `wait_then_restart` or `kill_then_restart` |
 on_success | the action to run when there's no error, warning or test failures |
 watch | a list of files and directories that will be watched if the job is run on a package. Usual source directories are implicitly included unless `default_watch` is set to false |
 


### PR DESCRIPTION
This PR brings 2 settings:

With `show_changes_count = true`, you can see the number of file changes that occurred since last job start.

The `on_change_strategy` setting lets you define how bacon reacts to a change, with two possible values:

* With `on_change_strategy = "kill_then_restart"`, the current job is immediately killed and a new job restarted. This is the behavior that bacon had before this PR.  It has the downside of never allowing any job to complete if you're always changing files and the job is just a little too long to finish between changes.

* With `on_change_strategy = "wait_then_restart"` (which is the new default, so you can omit it), bacon waits for the job to finish before restarting it. This is probably much better when the jobs aren't instant and you want to continue changing files while it's computing.

The `on_change_strategy` can be defined in the global prefs, in the project settings, and even for a specific job.

Fix #206