### PR TITLE
Quote `bacon --prefs` in shortcut examples

### DIFF
--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -17,7 +17,7 @@ When you modified those files and bacon evolved since, you may want to have a lo
 
 `bacon --prefs` creates the preferences file if it doesn't exist and returns its path (which is system dependent).
 
-You may run `$EDITOR $(bacon --prefs)` to edit it directly.
+You may run `$EDITOR "$(bacon --prefs)"` to edit it directly.
 
 The default configuration file contains already possible entries that you may uncomment and modify.
 

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -62,7 +62,7 @@ To create a default preferences file, use `bacon --prefs`.
 
 Shortcut:
 
-    $EDITOR $(bacon --prefs)
+    $EDITOR "$(bacon --prefs)"
 
 ## Project Settings
 


### PR DESCRIPTION
There may be spaces in the preference file's path, this ensures it's treated as a single argument.

For example, on macOS:
```sh
$ bacon --prefs
/Users/cpick/Library/Application Support/org.dystroy.bacon/prefs.toml
```