### PR TITLE
`BACON_PREFS` and `BACON_CONFIG` env vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - new `exports` structure in configuration. New `analysis` export bound by default to `ctrl-e`. The old syntax defining locations export is still supported but won't appear in documentations anymore.
 - recognize panic location in test - Fix #208
 - `toggle-backtrace` accepts an optional level: `toggle-backtrace(1)` or `toggle-backtrace(full)` - Experimental - Fix #210
+- configuration can be passed in `BACON_PREFS` and `BACON_CONFIG` env vars - Fix #76
 
 <a name="v2.21.0"></a>
 ### v2.21.0 - 2024/09/14

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -73,6 +73,10 @@ pub fn run() -> anyhow::Result<()> {
         }
     }
 
+    if let Some(config) = Config::from_env("BACON_PREFS")? {
+        settings.apply_config(&config);
+    }
+
     let location = MissionLocation::new(&args)?;
     info!("mission location: {:#?}", &location);
 
@@ -99,6 +103,10 @@ pub fn run() -> anyhow::Result<()> {
     }
     if package_config_path.exists() {
         let config = Config::from_path(&package_config_path)?;
+        settings.apply_config(&config);
+    }
+
+    if let Some(config) = Config::from_env("BACON_CONFIG")? {
         settings.apply_config(&config);
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,7 +10,7 @@ use {
     },
 };
 
-/// A configuration item which may be stored either as `bacon.toml`
+/// A configuration item which may be stored in various places, eg as `bacon.toml`
 /// along a `Cargo.toml` file or as `prefs.toml` in the xdg config directory.
 ///
 /// Leaf values are options (and not Default) so that they don't
@@ -65,6 +65,27 @@ impl Config {
             }
         }
         Ok(conf)
+    }
+    pub fn from_env(env_var_name: &str) -> Result<Option<Self>> {
+        let Some(path) = std::env::var_os(env_var_name) else {
+            return Ok(None);
+        };
+        let path = Path::new(&path);
+        if !path.exists() {
+            // some users may want to use an env var to point to a file that may not always exist
+            // so we don't bail here
+            warn!(
+                "Env var {:?} points to file {:?} which does not exist",
+                env_var_name, path
+            );
+            return Ok(None);
+        }
+        let config = Self::from_path(path)?;
+        debug!(
+            "Loaded config at {:?} as specified in env var {:?}",
+            path, env_var_name
+        );
+        Ok(Some(config))
     }
     pub fn default_package_config() -> Self {
         toml::from_str(DEFAULT_PACKAGE_CONFIG).unwrap()

--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -1,12 +1,19 @@
 
 # Configuration Files
 
-The behavior of bacon is defined by a global `prefs.toml` file and project specific `bacon.toml` files.
-
-All configuration files are optional but you'll soon need specific jobs for your targets, examples, etc.
+All configuration files are optional but you'll probably need specific jobs for your targets, examples, etc.
 
 All accept the same properties (preferences, keybindings, jobs, etc.).
-The properties of the global `prefs.toml` file are overriden by the workspace level `bacon.toml` file, then by the package level `bacon.toml` file.
+
+Bacon loads its default configuration then, in order:
+
+* the global `prefs.toml` ([global preferences](#global-preferences))
+* the file whose path is in environment variable `BACON_PREFS`
+* the workspace level `bacon.toml` file
+* the package level `bacon.toml` file ([project settings](#project-settings))
+* the file whose path is in environment variable `BACON_CONFIG`
+
+Each configuration file overrides the properties of previously loaded ones.
 
 When you modified those files and bacon evolved since, you may want to have a look at the current default ones and pick the changes you like:
 

--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -15,7 +15,7 @@ Bacon loads its default configuration then, in order:
 
 Each configuration file overrides the properties of previously loaded ones.
 
-When you modified those files and bacon evolved since, you may want to have a look at the current default ones and pick the changes you like:
+When you modified those files and bacon evolved since, you may want to have a look at the current default ones:
 
 * [Current default prefs.toml](https://raw.githubusercontent.com/Canop/bacon/main/defaults/default-prefs.toml)
 * [Current default bacon.toml](https://raw.githubusercontent.com/Canop/bacon/main/defaults/default-bacon.toml)


### PR DESCRIPTION
Bacon loads its default configuration then, in order:

* the global `prefs.toml`
* the file whose path is in environment variable `BACON_PREFS`
* the workspace level `bacon.toml` file
* the package level `bacon.toml` file
* the file whose path is in environment variable `BACON_CONFIG`

Fix #76