### PR TITLE
Fix prefs.toml path quoting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,6 +142,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_json",
+ "shlex",
  "termimad",
  "toml",
  "unicode-width",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ notify = "6.1"
 rustc-hash = "2"
 serde = { version = "1.0.210", features = ["derive"] }
 serde_json = "1.0"
+shlex = "1.3"
 termimad = "0.30"
 toml = "0.8"
 unicode-width = "0.1.12"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,6 +6,7 @@ use {
         fs,
         io::Write,
     },
+    shlex::try_quote,
     termimad::{
         EventSource,
         EventSourceOptions,
@@ -63,7 +64,7 @@ pub fn run() -> anyhow::Result<()> {
                 //  $EDITOR "$(bacon --prefs)"
                 eprintln!("Preferences file written.");
             }
-            println!("{}", prefs_path.to_string_lossy());
+            println!("{}", try_quote(&prefs_path.to_string_lossy())?);
             return Ok(());
         }
         if prefs_path.exists() {


### PR DESCRIPTION
On macOS, when I run:
`$EDITOR $(bacon --prefs)`
My editor tries to open:
`/Users/name/repository/Support/org.dystroy.bacon/prefs.toml`,
rather than the correct path:
`/Users/name/Library/Application Support/org.dystroy.bacon/prefs.toml`.

This can be fixed by quoting the path, either in `bacon`, or in the documentation. This PR fixes `bacon`.