### PR TITLE
Remove trailing space from default-prefs.toml

### DIFF
--- a/defaults/default-prefs.toml
+++ b/defaults/default-prefs.toml
@@ -46,7 +46,7 @@
 # (See https://dystroy.org/bacon/config/#export-locations),
 #
 # Possible line_format parts:
-#  - kind: warning|error|test 
+#  - kind: warning|error|test
 #  - path: complete absolute path to the file
 #  - line: 1-based line number
 #  - column: 1-based column


### PR DESCRIPTION
This is a nitpick, but some editors pick it up and highlight it (like mine).