### PR TITLE
Add note about running servers

### DIFF
--- a/website/docs/cookbook.md
+++ b/website/docs/cookbook.md
@@ -97,6 +97,17 @@ Depending on the desired output, you would have to add a setting to the run job,
 command = ["cargo", "run", "--color", "always", "--", "--color", "yes"]
 ```
 
+## Servers
+
+If your program never stops (e.g. a server), you may set `background = false` to have the `cargo run` output immediately displayed instead of waiting for the program's end. Additionally, if you prefer to have it restarted at every change, use `on_change_strategy = "kill_then_restart"`:
+
+```toml
+[jobs.webserver]
+command = ["cargo", "run", "--color", "always"]
+background = false
+on_change_strategy = "kill_then_restart"
+```
+
 # Gentler Kill
 
 The standard interruption of a job, occuring on quitting bacon and on refresh, may be too harsh for the program you run, especially if it's a long running program which should properly release resource.


### PR DESCRIPTION
I racked my brain for a little while about how to get my Axum server to rerun after changes were made while running bacon, and discovered the answer in https://github.com/Canop/bacon/issues/216, which pointed to updates made to the default bacon.toml file. The place I initially looked to try to solve this was in the [Cookbook](https://dystroy.org/bacon/cookbook/), under the section on running binaries. So, to make discovering how to resolve this issue easier for others, I took essentially what you wrote in the default bacon.toml file and added it to the Cookbook.