### PR TITLE
Update default-bacon.toml to add run-long job

### DIFF
--- a/defaults/default-bacon.toml
+++ b/defaults/default-bacon.toml
@@ -75,10 +75,6 @@ on_success = "back" # so that we don't open the browser at each change
 # *if* it makes sense for this crate.
 # Don't forget the `--color always` part or the errors won't be
 # properly parsed.
-# If your program never stops (eg a server), you may set `background`
-# to false to have the cargo run output immediately displayed instead
-# of waiting for program's end. If you prefer to have it restarted at
-# every change, then uncomment the 'on_change_strategy' line.
 [jobs.run]
 command = [
     "cargo", "run",
@@ -88,7 +84,22 @@ command = [
 need_stdout = true
 allow_warnings = true
 background = true
-#on_change_strategy = "kill_then_restart"
+
+# Run your long-running application and have the result displayed in bacon.
+# For programs that never stop (eg a server), `background` is set to false
+# to have the cargo run output immediately displayed instead of waiting for
+# program's end. 'on_change_strategy' is set to `kill_then_restart` to have
+# your program restart on every change.
+[jobs.run-long]
+command = [
+    "cargo", "run",
+    "--color", "always",
+    # put launch parameters for your program behind a `--` separator
+]
+need_stdout = true
+allow_warnings = true
+background = false
+on_change_strategy = "kill_then_restart"
 
 # This parameterized job runs the example of your choice, as soon
 # as the code compiles.


### PR DESCRIPTION
This change resolves #246 by adding a new `run-long` job to `default-bacon.toml`.