### PR TITLE
allow overriding default watched directories/files

### DIFF
--- a/defaults/default-bacon.toml
+++ b/defaults/default-bacon.toml
@@ -6,6 +6,7 @@
 #   https://github.com/Canop/bacon/blob/main/defaults/default-bacon.toml
 
 default_job = "check"
+default_watch = ["src", "tests", "benches", "examples", "build.rs"]
 
 [jobs.check]
 command = ["cargo", "check", "--color", "always"]

--- a/src/conf/config.rs
+++ b/src/conf/config.rs
@@ -3,11 +3,7 @@ use {
     anyhow::*,
     lazy_regex::regex_is_match,
     serde::Deserialize,
-    std::{
-        collections::HashMap,
-        fs,
-        path::Path,
-    },
+    std::{collections::HashMap, fs, path::Path},
 };
 
 /// A configuration item which may be stored in various places, eg as `bacon.toml`
@@ -20,6 +16,8 @@ pub struct Config {
     pub additional_alias_args: Option<Vec<String>>,
 
     pub default_job: Option<ConcreteJobRef>,
+
+    pub default_watch: Option<Vec<String>>,
 
     /// locations export
     #[deprecated(since = "2.22.0", note = "use exports.locations")]

--- a/src/conf/settings.rs
+++ b/src/conf/settings.rs
@@ -1,11 +1,7 @@
 use {
     crate::*,
     anyhow::*,
-    std::{
-        collections::HashMap,
-        path::PathBuf,
-        time::Duration,
-    },
+    std::{collections::HashMap, path::PathBuf, time::Duration},
 };
 
 /// The settings used in the application.
@@ -31,6 +27,7 @@ pub struct Settings {
     pub keybindings: KeyBindings,
     pub jobs: HashMap<String, Job>,
     pub default_job: ConcreteJobRef,
+    pub default_watch: Vec<String>,
     pub exports: ExportsSettings,
     pub show_changes_count: bool,
     pub on_change_strategy: Option<OnChangeStrategy>,
@@ -57,6 +54,9 @@ impl Default for Settings {
             keybindings: Default::default(),
             jobs: Default::default(),
             default_job: Default::default(),
+            default_watch: ["src", "tests", "benches", "examples", "build.rs"]
+                .map(String::from)
+                .into(),
             exports: Default::default(),
             show_changes_count: false,
             on_change_strategy: None,
@@ -175,6 +175,9 @@ impl Settings {
         }
         if let Some(default_job) = &config.default_job {
             self.default_job = default_job.clone();
+        }
+        if let Some(default_watch) = &config.default_watch {
+            self.default_watch = default_watch.clone();
         }
         self.exports.apply_config(config);
         if let Some(b) = config.show_changes_count {

--- a/src/mission.rs
+++ b/src/mission.rs
@@ -1,12 +1,7 @@
 use {
-    crate::*,
-    anyhow::Result,
-    lazy_regex::regex_replace_all,
-    rustc_hash::FxHashSet,
+    crate::*, anyhow::Result, lazy_regex::regex_replace_all, rustc_hash::FxHashSet,
     std::path::PathBuf,
 };
-
-static DEFAULT_WATCHES: &[&str] = &["src", "tests", "benches", "examples", "build.rs"];
 
 /// the description of the mission of bacon
 /// after analysis of the args, env, and surroundings
@@ -45,8 +40,8 @@ impl<'s> Mission<'s> {
                 if add_all_src {
                     let mut watches: Vec<&str> = job.watch.iter().map(|s| s.as_str()).collect();
                     if job.default_watch {
-                        for watch in DEFAULT_WATCHES {
-                            if !watches.contains(watch) {
+                        for watch in settings.default_watch.iter() {
+                            if !watches.contains(&watch.as_str()) {
                                 watches.push(watch);
                             }
                         }

--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -42,6 +42,14 @@ It's a good idea to put here the triggers for specific jobs.
 The [default bacon.toml](https://raw.githubusercontent.com/Canop/bacon/main/defaults/default-bacon.toml) is used when you don't create a file.
 
 
+# Global Settings
+
+field | meaning | default
+:-|:-|:-
+default_job | the job which should be executed at start if none is specified | `check`
+default_watch | list of files/directories to watch for changes in each project directory | `["src", "tests", "benches", "examples", "build.rs"]`
+
+
 # Jobs
 
 A job is a command which is ran by bacon in background, and whose result is analyzed and displayed on end.


### PR DESCRIPTION
Adds a new global configuration option `default_watch` to override the default set of files/directories used to detect changes (e.g. `["src", "tests", "benches", "examples", "build.rs"]`).