### PR TITLE
Project level watch list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### next
+Allow defining default_watch and watch at global level, so that they apply to all jobs unless overridden.
+
 <a name="v3.1.2"></a>
 ### v3.1.2 - 2024/10/29
 - "config loaded" message always automatically disappears after a few seconds

--- a/bacon.toml
+++ b/bacon.toml
@@ -10,7 +10,8 @@ command = [
 	"--color", "always",
 ]
 need_stdout = false
-watch = ["benches"]
+default_watch = false
+watch = ["src"]
 
 [jobs.check-all]
 command = [
@@ -19,7 +20,6 @@ command = [
 	"--color", "always",
 ]
 need_stdout = false
-watch = ["tests", "benches", "examples"]
 
 [jobs.nightly]
 command = [
@@ -30,7 +30,6 @@ command = [
 	"--color", "always",
 ]
 need_stdout = false
-watch = ["tests", "benches", "examples"]
 
 [jobs.win]
 command = [

--- a/src/conf/config.rs
+++ b/src/conf/config.rs
@@ -59,6 +59,21 @@ pub struct Config {
     /// task. Other file events occuring during this period will be
     /// ignored.
     pub grace_period: Option<Period>,
+
+    /// Whether to apply the default watch list, which is
+    /// `["src", "tests", "benches", "examples", "build.rs"]`
+    ///
+    /// This is true by default. Set it to false if you want
+    /// to watch nothing, or only the directories you set in
+    /// `watch`.
+    pub default_watch: Option<bool>,
+
+    /// A list of files and directories that will be watched if the job
+    /// is run on a package.
+    ///
+    /// src, examples, tests, benches, and build.rs are implicitly
+    /// included unless you `set default_watch` to false.
+    pub watch: Option<Vec<String>>,
 }
 
 impl Config {

--- a/src/conf/settings.rs
+++ b/src/conf/settings.rs
@@ -39,6 +39,8 @@ pub struct Settings {
     /// Path of the files which were used to build the settings
     /// (note that not all settings come from files)
     pub config_files: Vec<PathBuf>,
+    pub default_watch: bool,
+    pub watch: Vec<String>,
 }
 
 impl Default for Settings {
@@ -63,6 +65,8 @@ impl Default for Settings {
             ignored_lines: Default::default(),
             grace_period: Duration::from_millis(5).into(),
             config_files: Default::default(),
+            default_watch: true,
+            watch: Default::default(),
         }
     }
 }
@@ -188,6 +192,12 @@ impl Settings {
         }
         if let Some(p) = config.grace_period {
             self.grace_period = p;
+        }
+        if let Some(b) = config.default_watch {
+            self.default_watch = b;
+        }
+        if let Some(watch) = config.watch.as_ref() {
+            self.watch = watch.clone();
         }
     }
     pub fn apply_args(

--- a/src/jobs/job.rs
+++ b/src/jobs/job.rs
@@ -39,15 +39,6 @@ pub struct Job {
     /// A kill command. If not provided, SIGKILL is used.
     pub kill: Option<Vec<String>>,
 
-    /// Whether to apply the default watch list, which is
-    /// `["src", "tests", "benches", "examples"]`
-    ///
-    /// This is true by default. Set it to false if you want
-    /// to watch nothing, or only the directories you set in
-    /// `watch`.
-    #[serde(default = "default_true")]
-    pub default_watch: bool,
-
     /// Env vars to set for this job execution
     #[serde(default)]
     pub env: HashMap<String, String>,
@@ -66,16 +57,23 @@ pub struct Job {
     #[serde(default)]
     pub on_success: Option<Action>,
 
+    /// Whether to apply the default watch list, which is
+    /// `["src", "tests", "benches", "examples", "build.rs"]`
+    ///
+    /// This is true by default. Set it to false if you want
+    /// to watch nothing, or only the directories you set in
+    /// `watch`.
+    pub default_watch: Option<bool>,
+
     /// A list of directories that will be watched if the job
     /// is run on a package.
     /// src, examples, tests, and benches are implicitly included
     /// unless you `set default_watch` to false.
-    #[serde(default)]
-    pub watch: Vec<String>,
+    pub watch: Option<Vec<String>>,
 
-    // Whether to insert extraneous arguments provided by bacon or end users
-    //
-    // Eg: --all-features or anything after -- in bacon incantation
+    /// Whether to insert extraneous arguments provided by bacon or end users
+    ///
+    /// Eg: --all-features or anything after -- in bacon incantation
     #[serde(default = "default_true")]
     pub extraneous_args: bool,
 
@@ -119,9 +117,9 @@ impl Job {
         Self {
             command,
             kill: None,
-            default_watch: true,
+            default_watch: None,
             expand_env_vars: true,
-            watch: Vec::new(),
+            watch: None,
             need_stdout: false,
             on_success: None,
             allow_warnings: false,

--- a/src/mission.rs
+++ b/src/mission.rs
@@ -43,8 +43,15 @@ impl<'s> Mission<'s> {
                     .parent()
                     .expect("parent of a target folder is a root folder");
                 if add_all_src {
-                    let mut watches: Vec<&str> = job.watch.iter().map(|s| s.as_str()).collect();
-                    if job.default_watch {
+                    let mut watches: Vec<&str> = job
+                        .watch
+                        .as_ref()
+                        .unwrap_or(&settings.watch)
+                        .iter()
+                        .map(|s| s.as_str())
+                        .collect();
+                    let add_default = job.default_watch.unwrap_or(settings.default_watch);
+                    if add_default {
                         for watch in DEFAULT_WATCHES {
                             if !watches.contains(watch) {
                                 watches.push(watch);

--- a/website/docs/community.md
+++ b/website/docs/community.md
@@ -16,8 +16,10 @@ If it helps your company make money, consider helping me find time to add featur
 <script src="https://liberapay.com/dystroy/widgets/button.js"></script>
 <noscript><a href="https://liberapay.com/dystroy/donate"><img alt="Donate using Liberapay" src="https://liberapay.com/assets/widgets/donate.svg"></a></noscript>
 -->
-<iframe src="https://github.com/sponsors/Canop/button" title="Sponsor Canop" height="35" width="114" style="border: 0; border-radius: 6px;"></iframe>
+<iframe src="https://github.com/sponsors/Canop/button" title="Sponsor Canop" height="35" width="114" style="border: 0; border-radius: 6px;margin-bottom: 20px;"></iframe>
 </div>
+
+I'm also available for consulting or custom development. Head to [https://dystroy.org](https://dystroy.org) for references.
 
 # Chat
 

--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -77,12 +77,18 @@ command | the tokens making the command to execute (first one is the executable)
 default_watch | whether to watch default files (`src`, `tests`, `examples`, `build.rs`, and `benches`). When it's set to `false`, only the files in your `watch` parameter are watched | `true`
 env | a map of environment vars, for example `env.LOG_LEVEL="die"` |
 kill | a command replacing the default job interruption (platform dependant, `SIGKILL` on unix). For example `kill = ["kill", "-s", "INT"]` |
-ignored_lines | regular expressions for lines to ignores. If set before all jobs, will apply to all of them | none
+ignored_lines | regular expressions for lines to ignores |
 extraneous_args | if `false`, the action is run "as is" from `bacon.toml`, eg: no `--all-features` or `--features` inclusion | `true`
 need_stdout |whether we need to capture stdout too (stderr is always captured) | `false`
 on_change_strategy | `wait_then_restart` or `kill_then_restart` |
 on_success | the action to run when there's no error, warning or test failures |
 watch | a list of files and directories that will be watched if the job is run on a package. Usual source directories are implicitly included unless `default_watch` is set to false |
+
+Some of these properties can also be defined before jobs and will apply to all of them unless overriden: `watch`, `default_watch`, `ignored_lines`, and `on_change_strategy`.
+
+Don't forget to include `--color always` in most jobs, because bacon uses style information to parse the output of cargo.
+
+Beware of job references in `on_success`: you must avoid loops with 2 jobs calling themselves mutually, which would make bacon run all the time.
 
 Example:
 
@@ -91,10 +97,6 @@ Example:
 command = ["cargo", "run", "--example", "simple", "--color", "always"]
 need_stdout = true
 ```
-
-Don't forget to include `--color always` in most jobs, because bacon uses style information to parse the output of cargo.
-
-Beware of job references in `on_success`: you must avoid loops with 2 jobs calling themselves mutually, which would make bacon run all the time.
 
 ## Default Job
 
@@ -226,8 +228,8 @@ In the example here, locations are exported on each job execution while other ex
 
 # Other config properties
 
-Have a loot, at least once, at the default configuration files.
-They contain many other properties, commented out, that you may find more
+Have a look, at least once, at the default configuration files.
+They contain many other properties, commented out, that you may find useful.
 
 ## summary, wrap, reverse
 


### PR DESCRIPTION
Allow defining `default_watch` and `watch` at global level, so that they apply to all jobs unless overridden.

This should fulfill the need raised by https://github.com/Canop/bacon/pull/248 but IMO in a more consistent way with properties having the same name when global and job-specific.

Tests and comments welcome.
