### PR TITLE
Add root env vars to fix --color=always problem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - more lenient detection of warnings and errors due to 'miri run' not supporting `--color` - Fix #251
 - eslint analyzer (set `analyzer = "eslint"` in your job definition)
 - new `ignore` job parameter, accepts a list of glob patterns
+- allow defining environment vars for all jobs - Fix #261 and #124
 
 <a name="v3.2.0"></a>
 ### v3.2.0 - 2024/11/04

--- a/bacon.toml
+++ b/bacon.toml
@@ -1,14 +1,12 @@
 # a bacon.toml file dedicated to the bacon tool
 
 default_job = "check-all"
+env.CARGO_TERM_COLOR = "always"
 
 [jobs]
 
 [jobs.check]
-command = [
-	"cargo", "check",
-	"--color", "always",
-]
+command = ["cargo", "check"]
 need_stdout = false
 default_watch = false
 watch = ["src"]
@@ -17,7 +15,6 @@ watch = ["src"]
 command = [
 	"cargo", "check",
 	"--all-targets",
-	"--color", "always",
 ]
 need_stdout = false
 
@@ -27,7 +24,6 @@ command = [
 	"+nightly",
 	"check",
 	"--all-targets",
-	"--color", "always",
 ]
 need_stdout = false
 
@@ -38,26 +34,23 @@ command = [
 ]
 
 [jobs.test]
-command = [
-    "cargo", "test", "--color", "always",
-]
+command = ["cargo", "test"]
 need_stdout = true
 
 [jobs.doc]
-command = ["cargo", "doc", "--color", "always", "--no-deps"]
+command = ["cargo", "doc", "--no-deps"]
 need_stdout = false
 
 # If the doc compiles, then it opens in your browser and bacon switches
 # to the previous job
 [jobs.doc-open]
-command = ["cargo", "doc", "--color", "always", "--no-deps", "--open"]
+command = ["cargo", "doc", "--no-deps", "--open"]
 need_stdout = false
 on_success = "back" # so that we don't open the browser at each change
 
 [jobs.clippy-all]
 command = [
 	"cargo", "clippy",
-	"--color", "always",
 	"--",
 	"-A", "clippy::bool_to_int_with_if",
 	"-A", "clippy::collapsible_else_if",

--- a/defaults/default-bacon.toml
+++ b/defaults/default-bacon.toml
@@ -6,21 +6,19 @@
 #   https://github.com/Canop/bacon/blob/main/defaults/default-bacon.toml
 
 default_job = "check"
+env.CARGO_TERM_COLOR = "always"
 
 [jobs.check]
-command = ["cargo", "check", "--color", "always"]
+command = ["cargo", "check"]
 need_stdout = false
 
 [jobs.check-all]
-command = ["cargo", "check", "--all-targets", "--color", "always"]
+command = ["cargo", "check", "--all-targets"]
 need_stdout = false
 
 # Run clippy on the default target
 [jobs.clippy]
-command = [
-    "cargo", "clippy",
-    "--color", "always",
-]
+command = ["cargo", "clippy"]
 need_stdout = false
 
 # Run clippy on all targets
@@ -29,7 +27,6 @@ need_stdout = false
 #    command = [
 #        "cargo", "clippy",
 #        "--all-targets",
-#        "--color", "always",
 #    	 "--",
 #    	 "-A", "clippy::bool_to_int_with_if",
 #    	 "-A", "clippy::collapsible_if",
@@ -37,11 +34,7 @@ need_stdout = false
 #    ]
 # need_stdout = false
 [jobs.clippy-all]
-command = [
-    "cargo", "clippy",
-    "--all-targets",
-    "--color", "always",
-]
+command = ["cargo", "clippy", "--all-targets"]
 need_stdout = false
 
 # This job lets you run
@@ -49,29 +42,25 @@ need_stdout = false
 # - a specific test: bacon test -- config::test_default_files
 # - the tests of a package: bacon test -- -- -p config
 [jobs.test]
-command = [
-    "cargo", "test", "--color", "always",
-    "--", "--color", "always", # see https://github.com/Canop/bacon/issues/124
-]
+command = ["cargo", "test"]
 need_stdout = true
 
 [jobs.nextest]
 command = [
     "cargo", "nextest", "run",
-    "--color", "always",
     "--hide-progress-bar", "--failure-output", "final"
 ]
 need_stdout = true
 analyzer = "nextest"
 
 [jobs.doc]
-command = ["cargo", "doc", "--color", "always", "--no-deps"]
+command = ["cargo", "doc", "--no-deps"]
 need_stdout = false
 
 # If the doc compiles, then it opens in your browser and bacon switches
 # to the previous job
 [jobs.doc-open]
-command = ["cargo", "doc", "--color", "always", "--no-deps", "--open"]
+command = ["cargo", "doc", "--no-deps", "--open"]
 need_stdout = false
 on_success = "back" # so that we don't open the browser at each change
 
@@ -82,7 +71,6 @@ on_success = "back" # so that we don't open the browser at each change
 [jobs.run]
 command = [
     "cargo", "run",
-    "--color", "always",
     # put launch parameters for your program behind a `--` separator
 ]
 need_stdout = true
@@ -100,7 +88,6 @@ background = true
 [jobs.run-long]
 command = [
     "cargo", "run",
-    "--color", "always",
     # put launch parameters for your program behind a `--` separator
 ]
 need_stdout = true
@@ -113,7 +100,7 @@ on_change_strategy = "kill_then_restart"
 # Call it as
 #    bacon ex -- my-example
 [jobs.ex]
-command = ["cargo", "run", "--color", "always", "--example"]
+command = ["cargo", "run", "--example"]
 need_stdout = true
 allow_warnings = true
 

--- a/src/conf/config.rs
+++ b/src/conf/config.rs
@@ -78,6 +78,10 @@ pub struct Config {
     pub watch: Option<Vec<String>>,
 
     pub wrap: Option<bool>,
+
+    /// Env vars to set for all job executions
+    #[serde(default)]
+    pub env: HashMap<String, String>,
 }
 
 impl Config {

--- a/src/conf/settings.rs
+++ b/src/conf/settings.rs
@@ -1,14 +1,7 @@
 use {
     crate::*,
-    anyhow::{
-        Result,
-        bail,
-    },
-    std::{
-        collections::HashMap,
-        path::PathBuf,
-        time::Duration,
-    },
+    anyhow::{bail, Result},
+    std::{collections::HashMap, path::PathBuf, time::Duration},
 };
 
 /// The settings used in the application.
@@ -45,6 +38,7 @@ pub struct Settings {
     pub summary: bool,
     pub watch: Vec<String>,
     pub wrap: bool,
+    pub env: HashMap<String, String>,
 }
 
 impl Default for Settings {
@@ -72,6 +66,7 @@ impl Default for Settings {
             config_files: Default::default(),
             default_watch: true,
             watch: Default::default(),
+            env: Default::default(),
         }
     }
 }
@@ -156,6 +151,7 @@ impl Settings {
         &mut self,
         config: &Config,
     ) {
+        self.env.extend(config.env.clone());
         if let Some(b) = config.summary {
             self.summary = b;
         }

--- a/src/mission.rs
+++ b/src/mission.rs
@@ -2,6 +2,7 @@ use {
     crate::*,
     lazy_regex::regex_replace_all,
     rustc_hash::FxHashSet,
+    std::collections::HashMap,
     std::path::PathBuf,
 };
 
@@ -114,11 +115,16 @@ impl<'s> Mission<'s> {
             tokens.next().unwrap(), // implies a check in the job
         );
         command.with_stdout(self.need_stdout());
-
+        let envs: HashMap<&String, &String> = self
+            .settings
+            .env
+            .iter()
+            .chain(self.job.env.iter())
+            .collect();
         if !self.job.extraneous_args {
             command.args(tokens);
             command.current_dir(&self.execution_directory);
-            command.envs(&self.job.env);
+            command.envs(envs);
             debug!("command: {:#?}", &command);
             return command;
         }
@@ -197,7 +203,7 @@ impl<'s> Mission<'s> {
             }
         }
         command.current_dir(&self.execution_directory);
-        command.envs(&self.job.env);
+        command.envs(envs);
         debug!("command builder: {:#?}", &command);
         command
     }


### PR DESCRIPTION
Adds a new root level config item env, which allows setting environment
vars for all jobs. This makes it possible then to set CARGO_TERM_COLOR
to always, which fixes the problem with --color=always not working.

Fixes: #261 and #124
