### PR TITLE
python_ruff analyzer

### DIFF
--- a/src/analysis/analyzer.rs
+++ b/src/analysis/analyzer.rs
@@ -27,8 +27,9 @@ pub enum AnalyzerRef {
     Nextest,
     Eslint,
     Biome,
-    PythonUnittest,
     PythonPytest,
+    PythonRuff,
+    PythonUnittest,
 }
 
 impl AnalyzerRef {
@@ -40,6 +41,7 @@ impl AnalyzerRef {
             Self::Biome => Box::new(biome::BiomeAnalyzer::default()),
             Self::PythonUnittest => Box::new(python::unittest::UnittestAnalyzer::default()),
             Self::PythonPytest => Box::new(python::pytest::PytestAnalyzer::default()),
+            Self::PythonRuff => Box::new(python::ruff::RuffAnalyzer::default()),
             Self::CargoJson => Box::new(cargo_json::CargoJsonAnalyzer::default()),
         }
     }

--- a/src/analysis/python/mod.rs
+++ b/src/analysis/python/mod.rs
@@ -1,2 +1,3 @@
 pub mod pytest;
+pub mod ruff;
 pub mod unittest;

--- a/src/analysis/python/ruff.rs
+++ b/src/analysis/python/ruff.rs
@@ -1,0 +1,123 @@
+//! An analyzer for ruff ( https://docs.astral.sh/ruff/ )
+
+use {
+    crate::*,
+    anyhow::Result,
+    lazy_regex::*,
+};
+
+#[derive(Debug, Default)]
+pub struct RuffAnalyzer {
+    lines: Vec<CommandOutputLine>,
+}
+
+#[derive(Debug)]
+struct LocationTitle<'l> {
+    path: &'l str,
+    line: &'l str,
+    column: &'l str,
+    message: &'l [TString],
+}
+
+#[derive(Debug)]
+enum RuffLine<'l> {
+    LocationTitle(LocationTitle<'l>),
+    Other,
+}
+
+impl Analyzer for RuffAnalyzer {
+    fn start(
+        &mut self,
+        _mission: &Mission,
+    ) {
+        self.lines.clear();
+    }
+
+    fn receive_line(
+        &mut self,
+        line: CommandOutputLine,
+        command_output: &mut CommandOutput,
+    ) {
+        self.lines.push(line.clone());
+        command_output.push(line);
+    }
+
+    fn build_report(&mut self) -> Result<Report> {
+        build_report(&self.lines)
+    }
+}
+
+fn recognize_line(tline: &TLine) -> RuffLine {
+    if let Some(lt) = recognize_location_message(tline) {
+        return RuffLine::LocationTitle(lt);
+    }
+    RuffLine::Other
+}
+
+fn recognize_location_message(tline: &TLine) -> Option<LocationTitle> {
+    let tstrings = &tline.strings;
+    if tstrings.len() < 8 {
+        return None;
+    }
+    if tstrings[0].csi != "\u{1b}[1m" || tstrings[1].raw.is_empty() // path
+        || tstrings[1].csi != "\u{1b}[36m" || tstrings[1].raw != ":"
+        || tstrings[2].is_styled() || !regex_is_match!(r"^\d+$", &tstrings[2].raw) // line
+        || tstrings[3].csi != "\u{1b}[36m" || tstrings[3].raw != ":"
+        || tstrings[4].is_styled() || !regex_is_match!(r"^\d+$", &tstrings[4].raw) // column
+        || tstrings[5].csi != "\u{1b}[36m" || tstrings[5].raw != ":"
+        || tstrings[6].is_styled() || tstrings[6].raw != " "
+    {
+        return None;
+    }
+    Some(LocationTitle {
+        path: &tstrings[0].raw,
+        line: &tstrings[2].raw,
+        column: &tstrings[4].raw,
+        message: &tstrings[7..],
+    })
+}
+
+/// Build a report from the output of biome
+pub fn build_report(cmd_lines: &[CommandOutputLine]) -> anyhow::Result<Report> {
+    let mut items = ItemAccumulator::default();
+    let mut last_is_blank = true;
+    let mut i = 0;
+    for cmd_line in cmd_lines {
+        if i < 5 {
+            info!("cmd_line: {:#?}", &cmd_line);
+            i += 1;
+        }
+        let bline = recognize_line(&cmd_line.content);
+        if let RuffLine::LocationTitle(LocationTitle {
+            path,
+            line,
+            column,
+            message,
+        }) = bline
+        {
+            items.push_error_title(burp::error_line_ts(message));
+            items.push_line(
+                LineType::Location,
+                burp::location_line(format!("{}:{}:{}", path, line, column)),
+            );
+            last_is_blank = false;
+        } else {
+            let is_blank = cmd_line.content.is_blank();
+            if !(is_blank && last_is_blank) {
+                items.push_line(LineType::Normal, cmd_line.content.clone());
+            }
+            last_is_blank = is_blank;
+        }
+    }
+    let lines = items.lines();
+    let stats = Stats::from(&lines);
+    info!("stats: {:#?}", &stats);
+    let report = Report {
+        lines,
+        stats,
+        suggest_backtrace: false,
+        output: Default::default(),
+        failure_keys: Vec::new(),
+    };
+    Ok(report)
+}

--- a/src/burp/mod.rs
+++ b/src/burp/mod.rs
@@ -19,6 +19,14 @@ pub fn error_line(error: &str) -> TLine {
     line.strings.push(TString::new("", error.to_string()));
     line
 }
+/// Make a BURP compliant error line (title) from a [tstring]
+pub fn error_line_ts(error: &[TString]) -> TLine {
+    let mut line = TLine::default();
+    line.strings.push(TString::new(CSI_BOLD_RED, "error"));
+    line.strings.push(TString::new("", ": "));
+    line.strings.extend(error.iter().cloned());
+    line
+}
 /// Make a BURP compliant test failure line (title)
 /// (this one isn't based on cargo)
 pub fn failure_line(error: &str) -> TLine {

--- a/src/tty/tstring.rs
+++ b/src/tty/tstring.rs
@@ -123,6 +123,9 @@ impl TString {
     pub fn is_blank(&self) -> bool {
         self.raw.chars().all(char::is_whitespace)
     }
+    pub fn is_styled(&self) -> bool {
+        !self.csi.is_empty()
+    }
     pub fn is_unstyled(&self) -> bool {
         self.csi.is_empty()
     }


### PR DESCRIPTION
Exemple configuration:

```TOML
[jobs.ruff]
env.FORCE_COLOR = "1"
command = [
    "ruff", "check",
]
need_stdout = true
analyzer = "python_ruff"
watch = ["src"]
```

Normal:

![image](https://github.com/user-attachments/assets/e1ad839a-2420-4b3f-9dd6-8b4fabc88069)

Summarized:

![image](https://github.com/user-attachments/assets/821620ab-26d1-4ea0-ba9c-bdce96bd8a6d)

