### PR TITLE
iq based exporter, using cargo json data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,6 +136,7 @@ dependencies = [
  "directories-next",
  "gix",
  "glob",
+ "iq",
  "lazy-regex",
  "notify",
  "rustc-hash",
@@ -1207,6 +1208,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "iq"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef6f26340d47024663bf0180a65c9ca5e25776f606913695442d5219730f9da1"
+dependencies = [
+ "lazy-regex",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ crokey = "1.1"
 directories-next = "2.0.0"
 gix = { version = "0.67", default-features = false, features = ["index", "excludes", "parallel"] }
 glob = "0.3"
+iq = { version = "0.2", features = ["template"] }
 lazy-regex = "3.3"
 notify = "7.0"
 rustc-hash = "2"
@@ -42,4 +43,5 @@ codegen-units = 1
 # termimad = { path = "../termimad" }
 # crokey = { path = "../crokey" }
 # coolor = { path = "../coolor" }
+# iq = { path = "../iq" }
 # lazy-regex = { path = "../lazy-regex" }

--- a/bacon.toml
+++ b/bacon.toml
@@ -76,3 +76,11 @@ need_stdout = false
 
 [keybindings]
 c = "job:clippy-all"
+
+# an example of export based on the JSON export, active when
+# the analyzer is "cargo_json"
+[exports.cargo-json-spans]
+auto = false
+exporter = "analyzer"
+path = "bacon-analyser-export.json"
+line_format = "{span.file_name} {span.line_start}-{span.line_end} | {diagnostic.message} [{diagnostic.code}] level={diagnostic.level}"

--- a/defaults/default-prefs.toml
+++ b/defaults/default-prefs.toml
@@ -1,20 +1,24 @@
 # This is a preferences file for the bacon tool
 # More info at https://github.com/Canop/bacon
 
+
 # Uncomment and change the value (true/false) to
 # specify whether bacon should start in summary mode
 #
 # summary = true
+
 
 # Uncomment and change the value (true/false) to
 # specify whether bacon should start with lines wrapped
 #
 # wrap = false
 
+
 # In "reverse" mode, the focus is at the bottom, item
 # order is reversed, and the status bar is on top
 #
 # reverse = true
+
 
 # The grace period is a delay after a file event before the real
 # task is launched and during which other events will be ignored.
@@ -24,15 +28,18 @@
 #
 # grace_period = "5ms"
 
+
 # Uncomment and change the value (true/false) to
 # specify whether bacon should show a help line.
 #
 # help_line = false
 
+
 # Uncomment and change the value (true/false) to
 # set whether to display the count of changes since last job start
 #
 # show_changes_count = false
+
 
 # Uncomment one of those lines if you don't want the default
 # behavior triggered by a file change. This property can also
@@ -41,13 +48,7 @@
 # on_change_strategy = "kill_then_restart"
 # on_change_strategy = "wait_then_restart"
 
-# Exports can be executed either
-# - on each job completion (if auto is true)
-# - or called on a key (eg `ctrl-e = "export:analysis"`)
-#
-# They can be used for communication with external tools
-# or for inquiries.
-#
+
 # Exporting "locations" (by setting its 'auto' to true) lets you use
 # them in an external tool, for example as a list of jump locations
 # in an IDE or in a language server.
@@ -62,14 +63,10 @@
 #  - context: unstyled lines of output, separated with escaped newlines (`\\n`)
 [exports.locations]
 auto = false
+exporter = "locations"
 path = ".bacon-locations"
 line_format = "{kind} {path}:{line}:{column} {message}"
-[exports.json-report]
-auto = false
-path = "bacon-report.json"
-[exports.analysis]
-auto = false
-path = "bacon-analysis.json"
+
 
 # Uncomment and change the key-bindings you want to define
 # (some of those ones are the defaults and are just here for illustration)

--- a/src/analysis/cargo_json/cargo_json_export.rs
+++ b/src/analysis/cargo_json/cargo_json_export.rs
@@ -1,0 +1,49 @@
+use {
+    crate::*,
+    cargo_metadata::diagnostic::{
+        Diagnostic,
+        DiagnosticSpan,
+    },
+    serde::Serialize,
+};
+
+/// An export in progress for the cargo_json analyzer
+pub struct CargoJsonExport {
+    pub name: String,
+    /// The written data to write to the file
+    pub export: String,
+    pub line_template: iq::Template,
+}
+
+/// The data provided to the template, once per span
+#[derive(Debug, Clone, Serialize)]
+struct OnSpanData<'d> {
+    diagnostic: &'d Diagnostic,
+    span: &'d DiagnosticSpan,
+}
+
+impl CargoJsonExport {
+    pub fn new(
+        name: String,
+        settings: &ExportSettings,
+    ) -> Self {
+        Self {
+            name,
+            export: String::new(),
+            line_template: iq::Template::new(&settings.line_format),
+        }
+    }
+    pub fn receive_diagnostic(
+        &mut self,
+        diagnostic: &Diagnostic,
+    ) {
+        for span in &diagnostic.spans {
+            let data = OnSpanData { diagnostic, span };
+            let line = self.line_template.render(&data);
+            if !line.is_empty() {
+                self.export.push_str(&line);
+                self.export.push('\n');
+            }
+        }
+    }
+}

--- a/src/analysis/item_accumulator.rs
+++ b/src/analysis/item_accumulator.rs
@@ -76,6 +76,7 @@ impl ItemAccumulator {
             suggest_backtrace: false,
             output: Default::default(),
             failure_keys: Vec::new(),
+            analyzer_exports: Default::default(),
         }
     }
 }

--- a/src/analysis/standard/standard_line_analyser.rs
+++ b/src/analysis/standard/standard_line_analyser.rs
@@ -91,6 +91,9 @@ fn analyze_line(cmd_line: &CommandOutputLine) -> LineAnalysis {
                 ("", title_raw, CSI_BOLD_BLUE, "--> ") if is_spaces(title_raw) => {
                     LineType::Location
                 }
+                ("", title_raw, CSI_BOLD_BLUE, "::: ") if is_spaces(title_raw) => {
+                    LineType::Location
+                }
                 ("", k, CSI_BOLD_RED | CSI_RED, "FAILED") if content.strings.len() == 2 => {
                     if let Some(k) = as_test_name(k) {
                         key = Some(k.to_string());

--- a/src/analysis/standard/standard_report_building.rs
+++ b/src/analysis/standard/standard_report_building.rs
@@ -148,6 +148,7 @@ pub fn build_report<L: LineAnalyzer>(
         suggest_backtrace,
         output: Default::default(),
         failure_keys,
+        analyzer_exports: Default::default(),
     };
     Ok(report)
 }

--- a/src/export/export_settings.rs
+++ b/src/export/export_settings.rs
@@ -17,6 +17,7 @@ pub struct ExportSettings {
 impl ExportSettings {
     pub fn do_export(
         &self,
+        name: &str,
         state: &AppState<'_>,
     ) -> anyhow::Result<()> {
         let path = if self.path.is_relative() {
@@ -25,23 +26,26 @@ impl ExportSettings {
             self.path.to_path_buf()
         };
         info!("exporting to {:?}", path);
+        let Some(report) = state.cmd_result.report() else {
+            info!("No report to export");
+            return Ok(());
+        };
         match self.exporter {
+            Exporter::Analyser => {
+                if let Some(export) = report.analyzer_exports.get(name) {
+                    std::fs::write(&path, export)?;
+                } else {
+                    info!("Analyzer didn't build export {:?}", name);
+                }
+            }
             Exporter::Analysis => {
                 error!("Aanlysis export not currently implemented");
             }
             Exporter::JsonReport => {
-                let Some(report) = state.cmd_result.report() else {
-                    info!("No report to export");
-                    return Ok(());
-                };
                 let json = serde_json::to_string_pretty(&report)?;
                 std::fs::write(&path, json)?;
             }
             Exporter::Locations => {
-                let Some(report) = state.cmd_result.report() else {
-                    info!("No report to export");
-                    return Ok(());
-                };
                 let mut file = File::create(path)?;
                 report.write_locations(&mut file, &state.mission, &self.line_format)?;
             }

--- a/src/export/exporter.rs
+++ b/src/export/exporter.rs
@@ -1,7 +1,14 @@
 use serde::Deserialize;
 
-#[derive(Debug, Clone, Copy, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum Exporter {
+    /// The analyzer is tasked with doing an export while analyzing the
+    /// command output
+    #[serde(alias = "analyzer")]
+    Analyser,
+    /// This exporter doesn't exist at the moment
+    #[serde(alias = "analyzis")]
     Analysis,
     JsonReport,
     Locations,

--- a/src/export/exports_settings.rs
+++ b/src/export/exports_settings.rs
@@ -31,7 +31,7 @@ impl ExportsSettings {
         for (name, export) in &self.exports {
             if export.auto {
                 info!("doing auto export {:?}", name);
-                if let Err(e) = export.do_export(state) {
+                if let Err(e) = export.do_export(name, state) {
                     error!("error while exporting {:?}: {:?}", name, e);
                 }
             }
@@ -44,7 +44,7 @@ impl ExportsSettings {
         state: &AppState<'_>,
     ) {
         if let Some(export) = self.exports.get(requested_name) {
-            if let Err(e) = export.do_export(state) {
+            if let Err(e) = export.do_export(requested_name, state) {
                 error!("error while exporting {:?}: {:?}", requested_name, e);
             }
         } else {
@@ -99,6 +99,7 @@ impl ExportsSettings {
             };
             let auto = ec.auto.unwrap_or(true);
             let path = ec.path.clone().unwrap_or_else(|| match exporter {
+                Exporter::Analyser => default_analyser_path(),
                 Exporter::Analysis => default_analysis_path(),
                 Exporter::Locations => default_locations_path(),
                 Exporter::JsonReport => default_json_report_path(),
@@ -201,6 +202,9 @@ pub fn default_locations_line_format() -> &'static str {
     "{kind} {path}:{line}:{column} {message}"
 }
 
+pub fn default_analyser_path() -> PathBuf {
+    PathBuf::from("bacon-analyser.json")
+}
 pub fn default_analysis_path() -> PathBuf {
     PathBuf::from("bacon-analysis.json")
 }

--- a/src/result/report.rs
+++ b/src/result/report.rs
@@ -7,6 +7,7 @@ use {
         Serialize,
     },
     std::{
+        collections::HashMap,
         io,
         path::PathBuf,
     },
@@ -21,6 +22,8 @@ pub struct Report {
     pub suggest_backtrace: bool,
     pub output: CommandOutput,
     pub failure_keys: Vec<String>,
+    /// the exports that the analyzers have done, by name
+    pub analyzer_exports: HashMap<String, String>,
 }
 
 impl Report {


### PR DESCRIPTION
This adds a new exporter category allowing analyzers do produce the exported file.

The cargo_json analyzer exports the data of cargo's metadata [`Diagnostic`](https://docs.rs/cargo_metadata/0.19.1/cargo_metadata/diagnostic/struct.Diagnostic.html) and [`DiagnosticSpan`](https://docs.rs/cargo_metadata/0.19.1/cargo_metadata/diagnostic/struct.DiagnosticSpan.html), one line per span with a "field path" based syntax.

The bacon.toml file has an example of such export:

```TOML
# an example of export based on the JSON export, active when
# the analyzer is "cargo_json"
[exports.cargo-json-spans]
auto = false
exporter = "analyzer"
path = "bacon-analyser-export.json"
line_format = "{span.file_name} {span.line_start}-{span.line_end} | {diagnostic.message} [{diagnostic.code}] level={diagnostic.level}"
```

Fix #249