### PR TITLE
search input

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,7 +125,7 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "bacon"
-version = "3.6.0"
+version = "3.6.0-dev"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,7 +125,7 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "bacon"
-version = "3.6.0-dev"
+version = "3.6.0-dev-search"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bacon"
-version = "3.6.0"
+version = "3.6.0-dev"
 authors = ["dystroy <denys.seguret@gmail.com>"]
 repository = "https://github.com/Canop/bacon"
 description = "background rust compiler"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bacon"
-version = "3.6.0-dev"
+version = "3.6.0-dev-search"
 authors = ["dystroy <denys.seguret@gmail.com>"]
 repository = "https://github.com/Canop/bacon"
 description = "background rust compiler"

--- a/bacon.toml
+++ b/bacon.toml
@@ -76,3 +76,5 @@ need_stdout = false
 
 [keybindings]
 c = "job:clippy-all"
+n = "next-match"
+shift-n = "previous-match"

--- a/bacon.toml
+++ b/bacon.toml
@@ -76,5 +76,5 @@ need_stdout = false
 
 [keybindings]
 c = "job:clippy-all"
-n = "next-match"
-shift-n = "previous-match"
+#n = "next-match"
+#shift-n = "previous-match"

--- a/src/analysis/nextest/nextest_line_analyser.rs
+++ b/src/analysis/nextest/nextest_line_analyser.rs
@@ -85,7 +85,7 @@ fn is_error_test_run_failed(content: &TLine) -> bool {
 }
 
 fn is_canceling(content: &TLine) -> bool {
-    let Some(first) = content.strings.get(0) else {
+    let Some(first) = content.strings.first() else {
         return false;
     };
     first.csi == CSI_ERROR && first.raw.trim() == "Canceling"

--- a/src/app.rs
+++ b/src/app.rs
@@ -209,6 +209,12 @@ fn run_mission(
                             break;
                         }
                     }
+                    Internal::NextMatch => {
+                        state.next_match();
+                    }
+                    Internal::PreviousMatch => {
+                        state.previous_match();
+                    }
                     Internal::FocusSearch => {
                         state.focus_search();
                     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -171,7 +171,9 @@ fn run_mission(
                     Event::Key(key_event) => {
                         let key_combination = KeyCombination::from(key_event);
                         debug!("key combination pressed: {}", key_combination);
-                        action = keybindings.get(key_combination);
+                        if !state.apply_key_combination(key_combination) {
+                            action = keybindings.get(key_combination);
+                        }
                     }
                     #[cfg(windows)]
                     Event::Mouse(MouseEvent { kind: MouseEventKind::ScrollDown, .. }) => {
@@ -202,16 +204,26 @@ fn run_mission(
                 }
                 Action::Internal(internal) => match internal {
                     Internal::Back => {
-                        if !state.close_help() {
+                        if !state.back() {
                             do_after_mission = DoAfterMission::NextJob(JobRef::Previous);
                             break;
                         }
                     }
+                    Internal::FocusSearch => {
+                        state.focus_search();
+                    }
                     Internal::Help => {
                         state.toggle_help();
                     }
+                    Internal::Pause => {
+                        state.auto_refresh = AutoRefresh::Paused;
+                    }
                     Internal::Quit => {
                         break;
+                    }
+                    Internal::ReRun => {
+                        task_executor.die();
+                        task_executor = state.start_computation(&mut executor)?;
                     }
                     Internal::Refresh => {
                         state.clear();
@@ -222,10 +234,6 @@ fn run_mission(
                         do_after_mission = DoAfterMission::ReloadConfig;
                         break;
                     }
-                    Internal::ReRun => {
-                        task_executor.die();
-                        task_executor = state.start_computation(&mut executor)?;
-                    }
                     Internal::ScopeToFailures => {
                         if let Some(scope) = state.failures_scope() {
                             info!("scoping to failures: {scope:#?}");
@@ -235,34 +243,14 @@ fn run_mission(
                             warn!("no available failures scope");
                         }
                     }
-                    Internal::ToggleRawOutput => {
-                        state.toggle_raw_output();
-                    }
-                    Internal::ToggleSummary => {
-                        state.toggle_summary_mode();
-                    }
-                    Internal::ToggleWrap => {
-                        state.toggle_wrap_mode();
+                    Internal::Scroll(scroll_command) => {
+                        let scroll_command = *scroll_command;
+                        state.apply_scroll_command(scroll_command);
                     }
                     Internal::ToggleBacktrace(level) => {
                         state.toggle_backtrace(level);
                         task_executor.die();
                         task_executor = state.start_computation(&mut executor)?;
-                    }
-                    Internal::Scroll(scroll_command) => {
-                        let scroll_command = *scroll_command;
-                        state.apply_scroll_command(scroll_command);
-                    }
-                    Internal::Pause => {
-                        state.auto_refresh = AutoRefresh::Paused;
-                    }
-                    Internal::Unpause => {
-                        if state.changes_since_last_job_start > 0 {
-                            state.clear();
-                            task_executor.die();
-                            task_executor = state.start_computation(&mut executor)?;
-                        }
-                        state.auto_refresh = AutoRefresh::Enabled;
                     }
                     Internal::TogglePause => match state.auto_refresh {
                         AutoRefresh::Enabled => {
@@ -277,6 +265,26 @@ fn run_mission(
                             state.auto_refresh = AutoRefresh::Enabled;
                         }
                     },
+                    Internal::ToggleRawOutput => {
+                        state.toggle_raw_output();
+                    }
+                    Internal::ToggleSummary => {
+                        state.toggle_summary_mode();
+                    }
+                    Internal::ToggleWrap => {
+                        state.toggle_wrap_mode();
+                    }
+                    Internal::Unpause => {
+                        if state.changes_since_last_job_start > 0 {
+                            state.clear();
+                            task_executor.die();
+                            task_executor = state.start_computation(&mut executor)?;
+                        }
+                        state.auto_refresh = AutoRefresh::Enabled;
+                    }
+                    Internal::Validate => {
+                        state.validate();
+                    }
                 },
                 Action::Job(job_ref) => {
                     do_after_mission = job_ref.clone().into();

--- a/src/conf/keybindings.rs
+++ b/src/conf/keybindings.rs
@@ -49,6 +49,9 @@ impl Default for KeyBindings {
         bindings.set(key!(ctrl - d), JobRef::Default);
         bindings.set(key!(i), JobRef::Initial);
         bindings.set(key!(p), Internal::TogglePause);
+        bindings.set(key!('/'), Internal::FocusSearch);
+        bindings.set(key!(enter), Internal::Validate);
+
         // keybindings for some common jobs
         bindings.set(key!(a), JobRef::from_job_name("check-all"));
         bindings.set(key!(c), JobRef::from_job_name("clippy"));

--- a/src/conf/keybindings.rs
+++ b/src/conf/keybindings.rs
@@ -51,6 +51,8 @@ impl Default for KeyBindings {
         bindings.set(key!(p), Internal::TogglePause);
         bindings.set(key!('/'), Internal::FocusSearch);
         bindings.set(key!(enter), Internal::Validate);
+        bindings.set(key!(tab), Internal::NextMatch);
+        bindings.set(key!(shift - backtab), Internal::PreviousMatch);
 
         // keybindings for some common jobs
         bindings.set(key!(a), JobRef::from_job_name("check-all"));

--- a/src/conf/keybindings.rs
+++ b/src/conf/keybindings.rs
@@ -52,6 +52,7 @@ impl Default for KeyBindings {
         bindings.set(key!('/'), Internal::FocusSearch);
         bindings.set(key!(enter), Internal::Validate);
         bindings.set(key!(tab), Internal::NextMatch);
+        bindings.set(key!(backtab), Internal::PreviousMatch);
         bindings.set(key!(shift - backtab), Internal::PreviousMatch);
 
         // keybindings for some common jobs

--- a/src/drawing.rs
+++ b/src/drawing.rs
@@ -8,8 +8,18 @@ use {
     },
 };
 
-/// Move the curstor to the start of the provided line
+/// Move the curstor to the x, y position
 pub fn goto(
+    w: &mut W,
+    x: u16,
+    y: u16,
+) -> Result<()> {
+    execute!(w, cursor::MoveTo(x, y))?;
+    Ok(())
+}
+
+/// Move the curstor to the start of the provided line
+pub fn goto_line(
     w: &mut W,
     y: u16,
 ) -> Result<()> {

--- a/src/help/help_line.rs
+++ b/src/help/help_line.rs
@@ -11,6 +11,7 @@ pub struct HelpLine {
     pause: Option<String>,
     unpause: Option<String>,
     scope: Option<String>,
+    search: Option<String>,
 }
 
 impl HelpLine {
@@ -18,7 +19,7 @@ impl HelpLine {
         let kb = &settings.keybindings;
         let quit = kb
             .shortest_internal_key(Internal::Quit)
-            .map(|k| format!("Hit *{k}* to quit"))
+            .map(|k| format!("*{k}* to quit"))
             .expect("the app to be quittable");
         let toggle_summary = kb
             .shortest_internal_key(Internal::ToggleSummary)
@@ -52,6 +53,9 @@ impl HelpLine {
         let scope = kb
             .shortest_internal_key(Internal::ScopeToFailures)
             .map(|k| format!("*{k}* to scope to failures"));
+        let search = kb
+            .shortest_internal_key(Internal::FocusSearch)
+            .map(|k| format!("*{k}* to search"));
         Self {
             quit,
             toggle_summary,
@@ -63,14 +67,16 @@ impl HelpLine {
             pause,
             unpause,
             scope,
+            search,
         }
     }
     pub fn markdown(
         &self,
         state: &AppState,
     ) -> String {
-        let mut parts: Vec<&str> = vec![&self.quit];
+        let mut parts: Vec<&str> = Vec::new();
         if state.is_help() {
+            parts.push(&self.quit);
             if let Some(s) = &self.close_help {
                 parts.push(s);
             }
@@ -96,6 +102,14 @@ impl HelpLine {
                     }
                 }
             }
+            if !state.has_search() {
+                if let Some(s) = &self.search {
+                    parts.push(s);
+                }
+            }
+            if let Some(s) = &self.help {
+                parts.push(s);
+            }
             if state.wrap {
                 if let Some(s) = &self.not_wrap {
                     parts.push(s);
@@ -110,10 +124,8 @@ impl HelpLine {
                     parts.push(s);
                 }
             }
-            if let Some(s) = &self.help {
-                parts.push(s);
-            }
+            parts.push(&self.quit);
         }
-        parts.join(", ")
+        format!("Hit {}", parts.join(", "))
     }
 }

--- a/src/help/help_line.rs
+++ b/src/help/help_line.rs
@@ -12,6 +12,8 @@ pub struct HelpLine {
     unpause: Option<String>,
     scope: Option<String>,
     search: Option<String>,
+    next_match: Option<String>,
+    previous_match: Option<String>,
 }
 
 impl HelpLine {
@@ -56,6 +58,12 @@ impl HelpLine {
         let search = kb
             .shortest_internal_key(Internal::FocusSearch)
             .map(|k| format!("*{k}* to search"));
+        let next_match = kb
+            .shortest_internal_key(Internal::NextMatch)
+            .map(|k| format!("*{k}* for next match"));
+        let previous_match = kb
+            .shortest_internal_key(Internal::PreviousMatch)
+            .map(|k| format!("*{k}* for previous match"));
         Self {
             quit,
             toggle_summary,
@@ -68,6 +76,8 @@ impl HelpLine {
             unpause,
             scope,
             search,
+            next_match,
+            previous_match,
         }
     }
     pub fn markdown(
@@ -95,16 +105,24 @@ impl HelpLine {
                 if let Some(s) = &self.toggle_backtrace {
                     parts.push(s);
                 }
-            } else if let CommandResult::Report(report) = &state.cmd_result {
-                if !state.mission.is_success(report) {
-                    if let Some(s) = &self.toggle_summary {
-                        parts.push(s);
-                    }
-                }
             }
-            if !state.has_search() {
+            if state.has_search() {
+                if let Some(s) = &self.next_match {
+                    parts.push(s);
+                }
+                if let Some(s) = &self.previous_match {
+                    parts.push(s);
+                }
+            } else {
                 if let Some(s) = &self.search {
                     parts.push(s);
+                }
+                if let CommandResult::Report(report) = &state.cmd_result {
+                    if !state.mission.is_success(report) {
+                        if let Some(s) = &self.toggle_summary {
+                            parts.push(s);
+                        }
+                    }
                 }
             }
             if let Some(s) = &self.help {

--- a/src/help/help_page.rs
+++ b/src/help/help_page.rs
@@ -28,7 +28,7 @@ static TEMPLATE: &str = r#"
 See *https://dystroy.org/bacon* for a complete guide.
 
 |:-:|:-:
-|**action**|**shortcuts**
+|**action**|**shortcut**
 |:-|:-:
 ${keybindings
 |${action}|${keys}

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -34,6 +34,8 @@ pub enum Internal {
     ToggleWrap,
     Unpause,
     Validate, // validate search entry
+    NextMatch,
+    PreviousMatch,
 }
 
 impl Internal {
@@ -57,6 +59,8 @@ impl Internal {
             Self::Unpause => "unpause".to_string(),
             Self::FocusSearch => "focus search".to_string(),
             Self::Validate => "validate".to_string(),
+            Self::NextMatch => "next match".to_string(),
+            Self::PreviousMatch => "previous match".to_string(),
         }
     }
 }
@@ -84,6 +88,8 @@ impl fmt::Display for Internal {
             Self::Unpause => write!(f, "unpause"),
             Self::FocusSearch => write!(f, "focus-search"),
             Self::Validate => write!(f, "validate"),
+            Self::NextMatch => write!(f, "next-match"),
+            Self::PreviousMatch => write!(f, "previous-match"),
         }
     }
 }
@@ -113,6 +119,8 @@ impl std::str::FromStr for Internal {
             "toggle-pause" => Ok(Self::TogglePause),
             "focus-search" => Ok(Self::FocusSearch),
             "validate" => Ok(Self::Validate),
+            "next-match" => Ok(Self::NextMatch),
+            "previous-match" => Ok(Self::PreviousMatch),
             _ => Err("invalid internal"),
         }
     }
@@ -160,6 +168,8 @@ fn test_internal_string_round_trip() {
         Internal::ToggleWrap,
         Internal::Unpause,
         Internal::Validate,
+        Internal::NextMatch,
+        Internal::PreviousMatch,
     ];
     for internal in internals {
         assert_eq!(internal.to_string().parse(), Ok(internal));

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -17,7 +17,8 @@ use {
 /// to a key or ran after a successful job
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Internal {
-    Back,
+    Back, // leave help, clear search, go to previous job, leave, etc.
+    FocusSearch,
     Help,
     Pause,
     Quit,
@@ -32,6 +33,7 @@ pub enum Internal {
     ToggleSummary,
     ToggleWrap,
     Unpause,
+    Validate, // validate search entry
 }
 
 impl Internal {
@@ -53,6 +55,8 @@ impl Internal {
             Self::ToggleSummary => "toggle summary".to_string(),
             Self::ToggleWrap => "toggle wrap".to_string(),
             Self::Unpause => "unpause".to_string(),
+            Self::FocusSearch => "focus search".to_string(),
+            Self::Validate => "validate".to_string(),
         }
     }
 }
@@ -78,6 +82,8 @@ impl fmt::Display for Internal {
             Self::ToggleSummary => write!(f, "toggle-summary"),
             Self::ToggleWrap => write!(f, "toggle-wrap"),
             Self::Unpause => write!(f, "unpause"),
+            Self::FocusSearch => write!(f, "focus-search"),
+            Self::Validate => write!(f, "validate"),
         }
     }
 }
@@ -105,6 +111,8 @@ impl std::str::FromStr for Internal {
             "pause" => Ok(Self::Pause),
             "unpause" => Ok(Self::Unpause),
             "toggle-pause" => Ok(Self::TogglePause),
+            "focus-search" => Ok(Self::FocusSearch),
+            "validate" => Ok(Self::Validate),
             _ => Err("invalid internal"),
         }
     }
@@ -134,6 +142,7 @@ impl<'de> Deserialize<'de> for Internal {
 fn test_internal_string_round_trip() {
     let internals = [
         Internal::Back,
+        Internal::FocusSearch,
         Internal::Help,
         Internal::Pause,
         Internal::Quit,
@@ -150,6 +159,7 @@ fn test_internal_string_round_trip() {
         Internal::ToggleSummary,
         Internal::ToggleWrap,
         Internal::Unpause,
+        Internal::Validate,
     ];
     for internal in internals {
         assert_eq!(internal.to_string().parse(), Ok(internal));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ mod messages;
 mod mission;
 mod result;
 mod scroll;
+mod search;
 mod state;
 mod tty;
 mod watcher;
@@ -40,6 +41,7 @@ pub use {
     mission::*,
     result::*,
     scroll::*,
+    search::*,
     state::*,
     tty::*,
     watcher::*,

--- a/src/result/command_output.rs
+++ b/src/result/command_output.rs
@@ -26,6 +26,13 @@ pub struct CommandOutput {
     pub lines: Vec<CommandOutputLine>,
 }
 
+impl HasWrappableLines for CommandOutput {
+    type WL = CommandOutputLine;
+    fn wrappable_lines(&self) -> &[Self::WL] {
+        &self.lines
+    }
+}
+
 /// a piece of information about the execution of a command
 #[derive(Debug)]
 pub enum CommandExecInfo {
@@ -63,5 +70,19 @@ impl CommandOutput {
     }
     pub fn len(&self) -> usize {
         self.lines.len()
+    }
+}
+
+impl CommandOutputLine {
+    pub fn matches(
+        &self,
+        pattern: Option<&str>,
+    ) -> bool {
+        if let Some(pattern) = pattern {
+            if !self.content.has(pattern) {
+                return false;
+            }
+        }
+        true
     }
 }

--- a/src/result/command_output.rs
+++ b/src/result/command_output.rs
@@ -23,14 +23,7 @@ pub struct CommandOutputLine {
 /// some output lines
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct CommandOutput {
-    pub lines: Vec<CommandOutputLine>,
-}
-
-impl HasWrappableLines for CommandOutput {
-    type WL = CommandOutputLine;
-    fn wrappable_lines(&self) -> &[Self::WL] {
-        &self.lines
-    }
+    pub lines: Vec<Line>,
 }
 
 /// a piece of information about the execution of a command
@@ -49,40 +42,17 @@ pub enum CommandExecInfo {
     Line(CommandOutputLine),
 }
 
-impl WrappableLine for CommandOutputLine {
-    fn content(&self) -> &TLine {
-        &self.content
-    }
-    fn prefix_cols(&self) -> usize {
-        0
-    }
-}
-
 impl CommandOutput {
     pub fn reverse(&mut self) {
         self.lines.reverse()
     }
-    pub fn push(
+    pub fn push<L: Into<Line>>(
         &mut self,
-        line: CommandOutputLine,
+        line: L,
     ) {
-        self.lines.push(line);
+        self.lines.push(line.into());
     }
     pub fn len(&self) -> usize {
         self.lines.len()
-    }
-}
-
-impl CommandOutputLine {
-    pub fn matches(
-        &self,
-        pattern: Option<&str>,
-    ) -> bool {
-        if let Some(pattern) = pattern {
-            if !self.content.has(pattern) {
-                return false;
-            }
-        }
-        true
     }
 }

--- a/src/result/line.rs
+++ b/src/result/line.rs
@@ -76,6 +76,9 @@ impl Line {
         }
         Some(location_path)
     }
+    pub fn is_continuation(&self) -> bool {
+        matches!(self.line_type, LineType::Continuation { .. })
+    }
 }
 
 impl From<CommandOutputLine> for Line {

--- a/src/result/line.rs
+++ b/src/result/line.rs
@@ -41,6 +41,22 @@ impl Line {
         title
     }
 
+    pub fn matches(
+        &self,
+        summary: bool,
+        pattern: Option<&str>,
+    ) -> bool {
+        if summary && self.line_type == LineType::Normal {
+            return false;
+        }
+        if let Some(pattern) = pattern {
+            if !self.content.has(pattern) {
+                return false;
+            }
+        }
+        true
+    }
+
     /// Return the location as given by cargo
     /// It's usually relative and may contain the line and column
     pub fn location(&self) -> Option<&str> {

--- a/src/result/report.rs
+++ b/src/result/report.rs
@@ -26,13 +26,6 @@ pub struct Report {
     pub analyzer_exports: HashMap<String, String>,
 }
 
-impl HasWrappableLines for Report {
-    type WL = Line;
-    fn wrappable_lines(&self) -> &[Self::WL] {
-        &self.lines
-    }
-}
-
 impl Report {
     /// change the order of the lines so that items are in reverse order
     /// (but keep the order of lines of a given item)

--- a/src/result/report.rs
+++ b/src/result/report.rs
@@ -26,6 +26,13 @@ pub struct Report {
     pub analyzer_exports: HashMap<String, String>,
 }
 
+impl HasWrappableLines for Report {
+    type WL = Line;
+    fn wrappable_lines(&self) -> &[Self::WL] {
+        &self.lines
+    }
+}
+
 impl Report {
     /// change the order of the lines so that items are in reverse order
     /// (but keep the order of lines of a given item)

--- a/src/result/wrapped_command_output.rs
+++ b/src/result/wrapped_command_output.rs
@@ -4,7 +4,7 @@ use crate::*;
 /// contains references to the start and end of lines wrapped for a
 /// given width
 pub struct WrappedCommandOutput {
-    pub sub_lines: Vec<SubLine>,
+    pub sub_lines: Vec<Line>,
 
     /// in order to allow partial wrapping, and assuming the wrapped part
     /// didn't change, we store the count of lines which were wrapped so
@@ -34,11 +34,8 @@ impl WrappedCommandOutput {
         cmd_output: &CommandOutput,
         width: u16,
     ) {
-        let mut new_lines = wrap(&cmd_output.lines[self.wrapped_lines_count..], width);
-        for mut line in new_lines.drain(..) {
-            line.line_idx += self.wrapped_lines_count;
-            self.sub_lines.push(line);
-        }
+        self.sub_lines
+            .extend(wrap(&cmd_output.lines[self.wrapped_lines_count..], width));
         self.wrapped_lines_count = cmd_output.lines.len();
     }
 }

--- a/src/result/wrapped_report.rs
+++ b/src/result/wrapped_report.rs
@@ -1,10 +1,8 @@
 use crate::*;
 
-/// A wrapped report, only valid for the report it was computed for,
-/// contains references to the start and end of lines wrapped for a
-/// given width
 pub struct WrappedReport {
-    pub sub_lines: Vec<SubLine>,
+    pub sub_lines: Vec<Line>,
+    /// number of summary lines after wrapping
     pub summary_height: usize,
 }
 
@@ -20,26 +18,11 @@ impl WrappedReport {
         let sub_lines = wrap(&report.lines, width);
         let summary_height = sub_lines
             .iter()
-            .filter(|sl| {
-                report
-                    .lines
-                    .get(sl.line_idx)
-                    .map_or(true, |l| l.line_type != LineType::Normal)
-            })
+            .filter(|sl| sl.line_type.is_summary())
             .count();
         Self {
             sub_lines,
             summary_height,
-        }
-    }
-    pub fn content_height(
-        &self,
-        summary: bool,
-    ) -> usize {
-        if summary {
-            self.summary_height
-        } else {
-            self.sub_lines.len()
         }
     }
 }

--- a/src/search.rs
+++ b/src/search.rs
@@ -1,0 +1,49 @@
+use crate::*;
+
+// temporary struct, will need several tranges
+#[derive(Debug, PartialEq, Eq)]
+pub struct Found {
+    pub line_idx: usize,
+    pub trange: TRange,
+}
+
+pub struct Pattern {
+    pub pattern: String, // might change later
+}
+
+pub const CSI_FOUND: &str = "\u{1b}[1m\u{1b}[38;5;208m"; // bold, orange foreground
+pub const CSI_FOUND_SELECTED: &str = "\u{1b}[1m\u{1b}[30m\u{1b}[48;5;208m"; // bold, orange background
+
+impl Pattern {
+    // Current limitations:
+    // - match can't be split between two tstrings (and thus is broken on wrap)
+    pub fn search_lines(
+        &self,
+        lines: &[Line],
+    ) -> Vec<Found> {
+        let pattern = &self.pattern;
+        let mut founds = Vec::new();
+        for (line_idx, line) in lines.iter().enumerate() {
+            for (string_idx, tstring) in line.content.strings.iter().enumerate() {
+                let mut offset = 0;
+                while offset + pattern.len() < tstring.raw.len() {
+                    let haystack = &tstring.raw[offset..];
+                    let Some(pos) = haystack.find(pattern) else {
+                        break;
+                    };
+                    let found = Found {
+                        line_idx,
+                        trange: TRange {
+                            string_idx,
+                            start_byte_in_string: pos + offset,
+                            end_byte_in_string: pos + offset + pattern.len(),
+                        },
+                    };
+                    founds.push(found);
+                    offset += pos + pattern.len();
+                }
+            }
+        }
+        founds
+    }
+}

--- a/src/search.rs
+++ b/src/search.rs
@@ -1,10 +1,14 @@
 use crate::*;
 
-// temporary struct, will need several tranges
+/// position in a [TLine] of a found pattern
 #[derive(Debug, PartialEq, Eq)]
 pub struct Found {
+    /// The index of the first line containing the pattern
     pub line_idx: usize,
+    /// The range of the pattern in the line
     pub trange: TRange,
+    /// If the pattern goes over a line wrap, the range of the pattern in the next line
+    pub continued: Option<TRange>,
 }
 
 pub struct Pattern {
@@ -16,17 +20,45 @@ pub const CSI_FOUND_SELECTED: &str = "\u{1b}[1m\u{1b}[30m\u{1b}[48;5;208m"; // b
 
 impl Pattern {
     // Current limitations:
-    // - match can't be split between two tstrings (and thus is broken on wrap)
+    // - a match can't span over more than 2 lines. This is probably fine.
     pub fn search_lines(
         &self,
         lines: &[Line],
     ) -> Vec<Found> {
         let pattern = &self.pattern;
+        let len = pattern.len();
         let mut founds = Vec::new();
         for (line_idx, line) in lines.iter().enumerate() {
+            if line.is_continuation() && line_idx > 0 {
+                // we check for a match broken by wrapping
+                let previous_line = &lines[line_idx - 1];
+                if !previous_line.content.strings.is_empty() && !line.content.strings.is_empty() {
+                    let previous_line_string_idx = previous_line.content.strings.len() - 1;
+                    let previous_last_raw =
+                        &previous_line.content.strings[previous_line_string_idx].raw;
+                    if let Some(cut) =
+                        find_cut_pattern(pattern, previous_last_raw, &line.content.strings[0].raw)
+                    {
+                        let found = Found {
+                            line_idx: line_idx - 1,
+                            trange: TRange {
+                                string_idx: previous_line_string_idx,
+                                start_byte_in_string: previous_last_raw.len() - cut,
+                                end_byte_in_string: previous_last_raw.len(),
+                            },
+                            continued: Some(TRange {
+                                string_idx: 0,
+                                start_byte_in_string: 0,
+                                end_byte_in_string: len - cut,
+                            }),
+                        };
+                        founds.push(found);
+                    }
+                }
+            }
             for (string_idx, tstring) in line.content.strings.iter().enumerate() {
                 let mut offset = 0;
-                while offset + pattern.len() < tstring.raw.len() {
+                while offset + len < tstring.raw.len() {
                     let haystack = &tstring.raw[offset..];
                     let Some(pos) = haystack.find(pattern) else {
                         break;
@@ -38,6 +70,7 @@ impl Pattern {
                             start_byte_in_string: pos + offset,
                             end_byte_in_string: pos + offset + pattern.len(),
                         },
+                        continued: None,
                     };
                     founds.push(found);
                     offset += pos + pattern.len();
@@ -46,4 +79,13 @@ impl Pattern {
         }
         founds
     }
+}
+
+fn find_cut_pattern(
+    pattern: &str,
+    a: &str,
+    b: &str,
+) -> Option<usize> {
+    let len = pattern.len();
+    (1..len).find(|&i| a.ends_with(&pattern[..i]) && b.starts_with(&pattern[i..]))
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -764,7 +764,6 @@ impl<'s> AppState<'s> {
         if self.height < 4 {
             return Ok(());
         }
-        self.update_search();
         let area = Area::new(0, y, self.width - 1, self.page_height() as u16);
         let content_height = self.content_height();
         let scrollbar = area.scrollbar(self.scroll, content_height);
@@ -862,6 +861,7 @@ impl<'s> AppState<'s> {
         &mut self,
         w: &mut W,
     ) -> Result<()> {
+        self.update_search();
         if self.reverse {
             self.draw_status_line(w, 0)?;
             if let Some(help_page) = self.help_page.as_mut() {

--- a/src/state.rs
+++ b/src/state.rs
@@ -183,6 +183,9 @@ impl<'s> AppState<'s> {
     pub fn has_search(&self) -> bool {
         self.search_input.focused() || !self.search_input.is_empty()
     }
+    pub fn is_search_input_focused(&self) -> bool {
+        self.search_input.focused()
+    }
     /// handle a raw, uninterpreted key combination (in an input if there's one
     /// focused), return true if the key was consumed (if not, keybindings will
     /// be computed)
@@ -803,7 +806,6 @@ impl<'s> AppState<'s> {
                     let mut modified;
                     let previous_continuation = pending_continuation.take();
                     if previous_continuation.is_some() || !line_founds.is_empty() {
-                        info!("modify");
                         modified = tline.clone();
                         // We iterate on founds in reverse, so that we change the tline from
                         // the end, so that the tstring index in the founds stay valid when

--- a/src/state.rs
+++ b/src/state.rs
@@ -223,11 +223,27 @@ impl<'s> AppState<'s> {
         }
         self.search_up_to_date = true;
     }
+    /// Do a partial update for some potential added lines
+    pub fn update_search_from_line(
+        &mut self,
+        line_count_before: usize,
+    ) {
+        if self.search_input.is_empty() {
+            return;
+        }
+        let lines = self.lines_to_draw();
+        let pattern = Pattern {
+            pattern: self.search_input.get_content(),
+        };
+        let new_founds = pattern.search_lines(&lines[line_count_before..]);
+        self.founds.extend(new_founds);
+    }
     pub fn add_line(
         &mut self,
         line: CommandOutputLine,
     ) {
         let auto_scroll = self.is_scroll_at_bottom();
+        let line_count_before = self.lines_to_draw().len();
         if let Some(output) = self.output.as_mut() {
             self.report_maker.receive_line(line, output);
             if self.wrap {
@@ -247,7 +263,7 @@ impl<'s> AppState<'s> {
             self.scroll = 0;
             self.fix_scroll();
         }
-        self.search_up_to_date = false; // FIXME do just a partial update, don't recompute everything
+        self.update_search_from_line(line_count_before);
     }
     pub fn new_task(&self) -> Task {
         Task {

--- a/src/state.rs
+++ b/src/state.rs
@@ -618,11 +618,15 @@ impl<'s> AppState<'s> {
                 6,
             ));
         }
-        if !self.founds.is_empty() {
-            t_line.add_tstring(
-                CSI_FOUND,
-                format!("{}/{}", self.selected_found + 1, self.founds.len(),),
-            );
+        if !self.search_input.is_empty() {
+            if self.founds.is_empty() {
+                t_line.add_tstring(CSI_FOUND, "no match");
+            } else {
+                t_line.add_tstring(
+                    CSI_FOUND,
+                    format!("{}/{}", self.selected_found + 1, self.founds.len(),),
+                );
+            }
         }
         let width = self.width as usize;
         let cols = t_line.draw_in(w, width)?;

--- a/src/state.rs
+++ b/src/state.rs
@@ -552,7 +552,7 @@ impl<'s> AppState<'s> {
         let must_draw_search = self.search_input.focused() || !self.search_input.is_empty();
         if must_draw_search {
             goto_line(w, y)?;
-            write!(w, "/")?;
+            draw(w, CSI_FOUND, "/")?;
             let search_width = (self.width / 4).clamp(8, 26);
             self.search_input.change_area(1, y, search_width);
             self.search_input.display_on(w)?;
@@ -617,6 +617,12 @@ impl<'s> AppState<'s> {
                 235,
                 6,
             ));
+        }
+        if !self.founds.is_empty() {
+            t_line.add_tstring(
+                CSI_FOUND,
+                format!("{}/{}", self.selected_found + 1, self.founds.len(),),
+            );
         }
         let width = self.width as usize;
         let cols = t_line.draw_in(w, width)?;

--- a/src/tty/mod.rs
+++ b/src/tty/mod.rs
@@ -34,9 +34,28 @@ pub const CSI_BOLD_WHITE: &str = "\u{1b}[1m\u{1b}[38;5;15m";
 
 static TAB_REPLACEMENT: &str = "    ";
 
+use {
+    crate::W,
+    anyhow::Result,
+    std::io::Write,
+};
+
 pub use {
     tline::*,
     tline_builder::*,
     trange::*,
     tstring::*,
 };
+
+pub fn draw(
+    w: &mut W,
+    csi: &str,
+    raw: &str,
+) -> Result<()> {
+    if csi.is_empty() {
+        write!(w, "{}", raw)?;
+    } else {
+        write!(w, "{}{}{}", csi, raw, CSI_RESET,)?;
+    }
+    Ok(())
+}

--- a/src/tty/mod.rs
+++ b/src/tty/mod.rs
@@ -1,5 +1,6 @@
 mod tline;
 mod tline_builder;
+mod trange;
 mod tstring;
 
 pub const CSI_RESET: &str = "\u{1b}[0m\u{1b}[0m";
@@ -36,5 +37,6 @@ static TAB_REPLACEMENT: &str = "    ";
 pub use {
     tline::*,
     tline_builder::*,
+    trange::*,
     tstring::*,
 };

--- a/src/tty/tline.rs
+++ b/src/tty/tline.rs
@@ -21,6 +21,43 @@ pub struct TLine {
 }
 
 impl TLine {
+    pub fn change_range_style(
+        &mut self,
+        trange: TRange,
+        new_csi: String,
+    ) {
+        let TRange {
+            string_idx,
+            start_byte_in_string,
+            end_byte_in_string,
+        } = trange;
+        if string_idx >= self.strings.len() {
+            return;
+        }
+        let csi = &self.strings[string_idx].csi.clone();
+        let raw = &mut self.strings[string_idx].raw;
+        if start_byte_in_string >= raw.len() {
+            return;
+        }
+        if end_byte_in_string < raw.len() {
+            let after = raw[end_byte_in_string..].to_string();
+            raw.truncate(end_byte_in_string);
+            self.strings.insert(string_idx + 1, TString {
+                csi: csi.clone(),
+                raw: after,
+            });
+        }
+        let raw = &mut self.strings[string_idx].raw;
+        if start_byte_in_string > 0 {
+            let after = raw[start_byte_in_string..].to_string();
+            raw.truncate(start_byte_in_string);
+            self.strings[string_idx].csi = csi.clone();
+            self.strings.insert(string_idx + 1, TString {
+                csi: new_csi.to_string(),
+                raw: after,
+            });
+        }
+    }
     pub fn from_tty(tty: &str) -> Self {
         let tty_str: String;
         let tty = if tty.contains('\t') {

--- a/src/tty/tline.rs
+++ b/src/tty/tline.rs
@@ -128,6 +128,16 @@ impl TLine {
             raw: " ".to_string(),
         });
     }
+    pub fn add_tstring<C: Into<String>, R: Into<String>>(
+        &mut self,
+        csi: C,
+        raw: R,
+    ) {
+        self.strings.push(TString {
+            csi: csi.into(),
+            raw: raw.into(),
+        });
+    }
     pub fn draw(
         &self,
         w: &mut W,

--- a/src/tty/trange.rs
+++ b/src/tty/trange.rs
@@ -1,0 +1,7 @@
+/// A position in a tline
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TRange {
+    pub string_idx: usize,
+    pub start_byte_in_string: usize,
+    pub end_byte_in_string: usize,
+}

--- a/src/tty/tstring.rs
+++ b/src/tty/tstring.rs
@@ -82,12 +82,7 @@ impl TString {
         &self,
         w: &mut W,
     ) -> Result<()> {
-        if self.csi.is_empty() {
-            write!(w, "{}", &self.raw)?;
-        } else {
-            write!(w, "{}{}{}", &self.csi, &self.raw, CSI_RESET,)?;
-        }
-        Ok(())
+        draw(w, &self.csi, &self.raw)
     }
     /// draw the string but without taking more than cols_max cols.
     /// Return the number of cols written

--- a/src/wrap.rs
+++ b/src/wrap.rs
@@ -10,6 +10,10 @@ pub trait WrappableLine {
     fn content(&self) -> &TLine;
     fn prefix_cols(&self) -> usize;
 }
+pub trait HasWrappableLines {
+    type WL;
+    fn wrappable_lines(&self) -> &[Self::WL];
+}
 
 #[derive(Debug, Default)]
 pub struct SubString {
@@ -51,11 +55,16 @@ impl SubLine {
             sub_string.string_idx != 0 || sub_string.byte_start != 0
         })
     }
-    pub fn src_line<'r>(
+    pub fn src_line<'r, L, H>(
         &self,
-        report: &'r Report,
-    ) -> &'r Line {
-        &report.lines[self.line_idx]
+        report: &'r H,
+    ) -> &'r L
+    where
+        L: WrappableLine,
+        H: HasWrappableLines<WL = L>,
+    {
+        let lines = report.wrappable_lines();
+        &lines[self.line_idx]
     }
     pub fn src_line_type(
         &self,

--- a/src/wrap.rs
+++ b/src/wrap.rs
@@ -1,147 +1,59 @@
 use {
     crate::*,
-    anyhow::*,
-    std::io::Write,
     unicode_width::UnicodeWidthChar,
 };
 
-/// a line which can be wrapped
-pub trait WrappableLine {
-    fn content(&self) -> &TLine;
-    fn prefix_cols(&self) -> usize;
-}
-pub trait HasWrappableLines {
-    type WL;
-    fn wrappable_lines(&self) -> &[Self::WL];
-}
-
-#[derive(Debug, Default)]
-pub struct SubString {
-    pub string_idx: usize,
-    pub byte_start: usize,
-    pub byte_end: usize, // not included
-}
-impl SubString {
-    pub fn draw(
-        &self,
-        w: &mut W,
-        content: &TLine,
-    ) -> Result<()> {
-        let string = &content.strings[self.string_idx];
-        if string.csi.is_empty() {
-            write!(w, "{}", &string.raw[self.byte_start..self.byte_end])?;
-        } else {
-            write!(
-                w,
-                "{}{}{}",
-                &string.csi,
-                &string.raw[self.byte_start..self.byte_end],
-                CSI_RESET,
-            )?;
-        }
-        Ok(())
-    }
-}
-
-#[derive(Debug, Default)]
-pub struct SubLine {
-    pub line_idx: usize,
-    pub sub_strings: Vec<SubString>,
-}
-
-impl SubLine {
-    pub fn is_continuation(&self) -> bool {
-        self.sub_strings.get(0).map_or(false, |sub_string| {
-            sub_string.string_idx != 0 || sub_string.byte_start != 0
-        })
-    }
-    pub fn src_line<'r, L, H>(
-        &self,
-        report: &'r H,
-    ) -> &'r L
-    where
-        L: WrappableLine,
-        H: HasWrappableLines<WL = L>,
-    {
-        let lines = report.wrappable_lines();
-        &lines[self.line_idx]
-    }
-    pub fn src_line_type(
-        &self,
-        report: &Report,
-    ) -> LineType {
-        report.lines[self.line_idx].line_type
-    }
-    pub fn line_type(
-        &self,
-        report: &Report,
-    ) -> LineType {
-        if self.is_continuation() {
-            LineType::Normal
-        } else {
-            report.lines[self.line_idx].line_type
-        }
-    }
-    pub fn draw_line_type(
-        &self,
-        w: &mut W,
-        report: &Report,
-    ) -> Result<()> {
-        self.line_type(report)
-            .draw(w, report.lines[self.line_idx].item_idx)?;
-        Ok(())
-    }
-    pub fn draw<WL: WrappableLine>(
-        &self,
-        w: &mut W,
-        source_lines: &[WL],
-    ) -> Result<()> {
-        for ts in &self.sub_strings {
-            let content = &source_lines[self.line_idx].content();
-            ts.draw(w, content)?;
-        }
-        Ok(())
-    }
-}
-
 /// Wrap lines into sublines containing positions in the original lines
-pub fn wrap<WL: WrappableLine>(
-    lines: &[WL],
+pub fn wrap(
+    lines: &[Line],
     width: u16,
-) -> Vec<SubLine> {
+) -> Vec<Line> {
     let cols = width as usize - 1; // -1 for the probable scrollbar
     let mut sub_lines = Vec::new();
-    for (line_idx, line) in lines.iter().enumerate() {
-        sub_lines.push(SubLine {
-            line_idx,
-            sub_strings: Vec::new(),
+    for line in lines.iter() {
+        let summary = line.line_type.is_summary();
+        sub_lines.push(Line {
+            item_idx: line.item_idx,
+            content: TLine::default(),
+            line_type: line.line_type,
         });
-        let mut sub_cols = line.prefix_cols();
-        let strings = &line.content().strings;
-        for (string_idx, string) in strings.iter().enumerate() {
-            sub_lines.last_mut().unwrap().sub_strings.push(SubString {
-                string_idx,
-                byte_start: 0,
-                byte_end: string.raw.len(), // may be changed later on cut
-            });
+        let mut sub_cols = line.line_type.cols();
+        let mut wrap_idx = 0; // 1 for first continuation, etc.
+        for string in &line.content.strings {
+            sub_lines
+                .last_mut()
+                .unwrap()
+                .content
+                .strings
+                .push(string.clone()); // might be truncated later
+            let mut byte_offset = 0;
             for (byte_idx, c) in string.raw.char_indices() {
                 let char_cols = c.width().unwrap_or(0);
                 if sub_cols + char_cols > cols && sub_cols > 0 {
-                    sub_lines
+                    let last_string = sub_lines
                         .last_mut()
                         .unwrap()
-                        .sub_strings
+                        .content
+                        .strings
                         .last_mut()
-                        .unwrap()
-                        .byte_end = byte_idx;
-                    sub_lines.push(SubLine {
-                        line_idx,
-                        sub_strings: vec![SubString {
-                            string_idx,
-                            byte_start: byte_idx,
-                            byte_end: string.raw.len(), // may be changed later on cut
-                        }],
+                        .unwrap();
+                    let after_cut = TString::new(
+                        last_string.csi.clone(),
+                        last_string.raw[byte_idx - byte_offset..].to_string(),
+                    );
+                    last_string.raw.truncate(byte_idx - byte_offset);
+                    byte_offset = byte_idx;
+                    sub_lines.push(Line {
+                        item_idx: line.item_idx,
+                        content: TLine {
+                            strings: vec![after_cut],
+                        },
+                        line_type: LineType::Continuation {
+                            offset: wrap_idx,
+                            summary,
+                        },
                     });
+                    wrap_idx += 1;
                     sub_cols = char_cols;
                 } else {
                     sub_cols += char_cols;


### PR DESCRIPTION
Focus the search input with <kbd>/</kbd>.

When search input is focused, unfocus it with either :
* <kbd>esc</kbd>,  cancelling it
* <kbd>enter</kbd>,  freezing it

Navigate between matches with `tab` and `alt-tab`.

You can define other shortcuts, eg

```
[keybindings]
n = "next-match"
shift-n = "previous-match"
```

But those ones aren't ideal: they conflict with the <kbd>n</kbd> being currently bound to nextest, and they can't be used when the search is focused (you can hit <kbd>enter</kbd> before navigating but then you'll have to hit <kbd>/</kbd> again if you want to add to the pattern).

#224 