### PR TITLE
Show an error if the command fails to spawn

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -153,9 +153,8 @@ fn run_mission(
                             action = state.action();
                         }
                         CommandExecInfo::Error(e) => {
-                            warn!("error in computation: {}", e);
                             state.computation_stops();
-                            break;
+                            return Err(e.context(format!("error in computation for job '{}'", state.mission.concrete_job_ref.badge_label())));
                         }
                         CommandExecInfo::Interruption => {
                             debug!("command was interrupted (by us)");

--- a/src/exec/executor.rs
+++ b/src/exec/executor.rs
@@ -116,11 +116,13 @@ impl MissionExecutor {
                 thread::sleep(grace_period.duration);
             }
 
-            let child = command_builder.build().spawn();
-            let mut child = match child {
+            let mut cmd = command_builder.build();
+            let mut child = match cmd.spawn() {
                 Ok(child) => child,
                 Err(e) => {
-                    let _ = line_sender.send(CommandExecInfo::Error(e.to_string()));
+                    let _ = line_sender.send(CommandExecInfo::Error(
+                        anyhow::anyhow!(e).context(format!("failed to spawn {cmd:?}")),
+                    ));
                     return;
                 }
             };

--- a/src/result/command_output.rs
+++ b/src/result/command_output.rs
@@ -36,7 +36,7 @@ pub enum CommandExecInfo {
     Interruption,
 
     /// Execution failed
-    Error(String),
+    Error(anyhow::Error),
 
     /// Here's a line of output (coming from stderr or stdout)
     Line(CommandOutputLine),

--- a/src/state.rs
+++ b/src/state.rs
@@ -727,9 +727,10 @@ impl<'s> AppState<'s> {
         }
     }
     fn lines_to_draw(&self) -> impl Iterator<Item = &Line> {
-        self.lines_to_draw_unfiltered()
-            .iter()
-            .filter(|line| line.matches(self.summary))
+        self.lines_to_draw_unfiltered().iter().filter(|line| {
+            // if this command failed, always show the output
+            matches!(self.cmd_result, CommandResult::Failure(..)) || line.matches(self.summary)
+        })
     }
     fn report_to_draw(&self) -> Option<&Report> {
         self.cmd_result


### PR DESCRIPTION
Before, bacon showed no output at all if spawning failed. Now, it gives a useful error instead:
```
Error: error in computation for job 'run'

Caused by:
    0: failed to spawn cd "../example" && CARGO_TERM_COLOR="always" RUST_BACKTRACE="0" "./run.sh"
    1: Exec format error (os error 8)
```

To test this, you can create a bacon.toml with `jobs.run.command = ["/not/here"]` and execute `bacon run`.