### PR TITLE
headless mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,6 +133,7 @@ dependencies = [
  "clap-help",
  "cli-log",
  "crokey",
+ "ctrlc",
  "directories-next",
  "gix",
  "glob",
@@ -448,6 +449,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "ctrlc"
+version = "3.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90eeab0aa92f3f9b4e87f258c72b139c207d251f9cbc1080a0086b86a8870dd3"
+dependencies = [
+ "nix",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ rust-version = "1.76"
         
 [dependencies]
 anyhow = "1.0"
+ctrlc = "3.4"
 cargo_metadata = "0.19"
 clap = { version = "4.5", features = ["derive", "cargo"] }
 clap-help = "1.3"
@@ -40,7 +41,7 @@ codegen-units = 1
 
 [patch.crates-io]
 # clap-help = { path = "../clap-help" }
-# termimad = { path = "../termimad" }
+# termimad = { path = "../termimad" }
 # crokey = { path = "../crokey" }
 # coolor = { path = "../coolor" }
 # iq = { path = "../iq" }

--- a/src/app.rs
+++ b/src/app.rs
@@ -45,6 +45,13 @@ pub fn run(
     headless: bool,
 ) -> Result<()> {
     let event_source = if headless {
+        // in headless mode, in some contexts, ctrl-c might not be enough to kill
+        // bacon so we add this handler
+        ctrlc::set_handler(move || {
+            eprintln!("bye");
+            std::process::exit(0);
+        })
+        .expect("Error setting Ctrl-C handler");
         None
     } else {
         Some(EventSource::with_options(EventSourceOptions {

--- a/src/app.rs
+++ b/src/app.rs
@@ -2,7 +2,10 @@ use {
     crate::*,
     anyhow::Result,
     crokey::*,
-    std::time::Duration,
+    std::{
+        io::Write,
+        time::Duration,
+    },
     termimad::{
         EventSource,
         EventSourceOptions,
@@ -39,11 +42,16 @@ pub fn run(
     mut settings: Settings,
     args: &Args,
     location: Context,
+    headless: bool,
 ) -> Result<()> {
-    let event_source = EventSource::with_options(EventSourceOptions {
-        combine_keys: false,
-        ..Default::default()
-    })?;
+    let event_source = if headless {
+        None
+    } else {
+        Some(EventSource::with_options(EventSourceOptions {
+            combine_keys: false,
+            ..Default::default()
+        })?)
+    };
     let mut job_stack = JobStack::default();
     let mut next_job = JobRef::Initial;
     let mut message = None;
@@ -55,7 +63,8 @@ pub fn run(
             }
         };
         let mission = location.mission(concrete_job_ref, job, &settings)?;
-        let do_after = app::run_mission(w, mission, &event_source, message.take())?;
+        let do_after =
+            app::run_mission(w, mission, event_source.as_ref(), message.take(), headless)?;
         match do_after {
             DoAfterMission::NextJob(job_ref) => {
                 next_job = job_ref;
@@ -81,8 +90,9 @@ pub fn run(
 fn run_mission(
     w: &mut W,
     mission: Mission,
-    event_source: &EventSource,
+    event_source: Option<&EventSource>,
     message: Option<Message>,
+    headless: bool,
 ) -> Result<DoAfterMission> {
     let keybindings = mission.settings.keybindings.clone();
 
@@ -100,12 +110,14 @@ fn run_mission(
         .on_change_strategy
         .or(mission.settings.on_change_strategy)
         .unwrap_or(OnChangeStrategy::WaitThenRestart);
-    let mut state = AppState::new(mission)?;
+    let mut state = AppState::new(mission, headless)?;
     if let Some(message) = message {
         state.messages.push(message);
     }
     state.computation_starts();
-    state.draw(w)?;
+    if !headless {
+        state.draw(w)?;
+    }
     let mut task_executor = executor.start(state.new_task())?; // first computation
 
     // A very low frequency tick generator, to ensure "config loaded" message doesn't stick
@@ -113,9 +125,17 @@ fn run_mission(
     let mut ticker = Ticker::new();
     ticker.tick_infinitely((), Duration::from_secs(5));
 
-    // loop on events
-    let user_events = event_source.receiver();
+    let _dummy_sender;
+    let user_events = if let Some(event_source) = event_source {
+        event_source.receiver()
+    } else {
+        let (sender, receiver) = termimad::crossbeam::channel::unbounded();
+        _dummy_sender = sender;
+        receiver
+    };
     let mut do_after_mission = DoAfterMission::Quit;
+
+    // loop on events
     #[allow(unused_mut)]
     loop {
         let mut action: Option<&Action> = None;
@@ -144,12 +164,26 @@ fn run_mission(
                 if let Ok(info) = info {
                     match info {
                         CommandExecInfo::Line(line) => {
+                            if headless {
+                                match line.origin {
+                                    CommandStream::StdOut => print!("{}", line.content),
+                                    CommandStream::StdErr => eprint!("{}", line.content),
+                                }
+                            }
+                            let line = line.into();
                             state.add_line(line);
                         }
                         CommandExecInfo::End { status } => {
                             // computation finished
                             info!("execution finished with status: {:?}", status);
                             state.finish_task(status)?;
+                            if headless {
+                                for badge in state.job_badges() {
+                                    badge.draw(w)?;
+                                }
+                                write!(w, "\n")?;
+                                w.flush()?;
+                            }
                             action = state.action();
                         }
                         CommandExecInfo::Error(e) => {
@@ -184,7 +218,9 @@ fn run_mission(
                     }
                     _ => {}
                 }
-                event_source.unblock(false);
+                if let Some(event_source) = event_source {
+                    event_source.unblock(false);
+                }
             }
         }
         if let Some(action) = action.take() {
@@ -297,7 +333,9 @@ fn run_mission(
                 }
             }
         }
-        state.draw(w)?;
+        if !headless {
+            state.draw(w)?;
+        }
     }
     task_executor.die();
     Ok(do_after_mission)

--- a/src/conf/args.rs
+++ b/src/conf/args.rs
@@ -44,6 +44,10 @@ pub struct Args {
     #[clap(long)]
     pub prefs: bool,
 
+    /// Run without user interface: just run the default job on change
+    #[clap(long)]
+    pub headless: bool,
+
     /// Start in summary mode
     #[clap(short = 's', long)]
     pub summary: bool,

--- a/src/exec/executor.rs
+++ b/src/exec/executor.rs
@@ -147,8 +147,8 @@ impl MissionExecutor {
                                 break;
                             }
                             Ok(_) => {
-                                let response = CommandExecInfo::Line(CommandOutputLine {
-                                    content: TLine::from_tty(&line),
+                                let response = CommandExecInfo::Line(RawCommandOutputLine {
+                                    content: line.clone(),
                                     origin: CommandStream::StdOut,
                                 });
                                 if sender.send(response).is_err() {
@@ -180,8 +180,8 @@ impl MissionExecutor {
                             break;
                         }
                         Ok(_) => {
-                            let response = CommandExecInfo::Line(CommandOutputLine {
-                                content: TLine::from_tty(&line),
+                            let response = CommandExecInfo::Line(RawCommandOutputLine {
+                                content: line.clone(),
                                 origin: CommandStream::StdErr,
                             });
                             if err_line_sender.send(response).is_err() {

--- a/src/result/command_output.rs
+++ b/src/result/command_output.rs
@@ -13,6 +13,13 @@ pub enum CommandStream {
     StdErr,
 }
 
+/// a line coming either from stdout or from stderr, before TTY parsing
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RawCommandOutputLine {
+    pub content: String,
+    pub origin: CommandStream,
+}
+
 /// a line coming either from stdout or from stderr
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CommandOutputLine {
@@ -39,7 +46,7 @@ pub enum CommandExecInfo {
     Error(anyhow::Error),
 
     /// Here's a line of output (coming from stderr or stdout)
-    Line(CommandOutputLine),
+    Line(RawCommandOutputLine),
 }
 
 impl CommandOutput {
@@ -54,5 +61,14 @@ impl CommandOutput {
     }
     pub fn len(&self) -> usize {
         self.lines.len()
+    }
+}
+
+impl From<RawCommandOutputLine> for CommandOutputLine {
+    fn from(raw: RawCommandOutputLine) -> Self {
+        CommandOutputLine {
+            content: TLine::from_tty(&raw.content),
+            origin: raw.origin,
+        }
     }
 }


### PR DESCRIPTION
When launched with `--headless`, bacon doesn't render the TUI and doesn't accept user events.

In this mode, it just displays the command output followed by a one line analysis:

![image](https://github.com/user-attachments/assets/d6703b68-3455-43fa-83d1-077be0bdf755)

Command output lines coming on stdout are rendered on stdout. If from stderr, they go to stderr.

Fix #293