### PR TITLE
add alias to job configuration

### DIFF
--- a/bacon.toml
+++ b/bacon.toml
@@ -38,6 +38,7 @@ command = [
 need_stdout = false
 
 [jobs.win]
+alias = ["windows"]
 command = [
 	"cross", "build",
 	"--target", "x86_64-pc-windows-gnu",

--- a/src/conf/settings.rs
+++ b/src/conf/settings.rs
@@ -249,10 +249,29 @@ impl Settings {
             bail!("Invalid configuration : no job found");
         }
         if let NameOrAlias::Name(name) = &self.default_job.name_or_alias {
-            if !self.jobs.contains_key(name) {
+            if self.job(name).is_none() {
                 bail!("Invalid configuration : default job ({name:?}) not found in jobs");
             }
         }
         Ok(())
+    }
+
+    /// Get a job by its name or alias.
+    pub fn job(
+        &self,
+        name: &str,
+    ) -> Option<&Job> {
+        self.jobs.iter().find_map(|(key, job)| {
+            if name == key
+                || job
+                    .alias
+                    .as_ref()
+                    .is_some_and(|alias| alias.iter().any(|alias| alias == name))
+            {
+                Some(job)
+            } else {
+                None
+            }
+        })
     }
 }

--- a/src/jobs/job.rs
+++ b/src/jobs/job.rs
@@ -7,6 +7,9 @@ use {
 /// One of the possible job that bacon can run
 #[derive(Debug, Clone, Deserialize)]
 pub struct Job {
+    /// List of alternative names to run this job.
+    pub alias: Option<Vec<String>>,
+
     /// Whether to consider that we can have a success
     /// when we have test failures
     #[serde(default)]
@@ -120,6 +123,7 @@ impl Job {
         }
         Self {
             command,
+            alias: None,
             kill: None,
             default_watch: None,
             expand_env_vars: true,

--- a/src/jobs/job_stack.rs
+++ b/src/jobs/job_stack.rs
@@ -63,8 +63,7 @@ impl JobStack {
         let job = match &concrete.name_or_alias {
             NameOrAlias::Alias(alias) => Job::from_alias(alias, settings),
             NameOrAlias::Name(name) => settings
-                .jobs
-                .get(name)
+                .job(name)
                 .ok_or_else(|| anyhow!("job not found: {:?}", name))?
                 .clone(),
         };

--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -75,6 +75,7 @@ The job is defined by the following fields:
 
 field | meaning | default
 :-|:-|:-
+alias | list of alternatives job names |
 allow_failures | if `true`, the action is considered a success even when there are test failures | `false`
 allow_warnings | if `true`, the action is considered a success even when there are warnings | `false`
 analyzer | command output parser, see below | `"standard"`


### PR DESCRIPTION
This allows you to write:

```toml
[jobs.example]
alias = ["ex"]
command = []
```

So you can do both `bacon example` and `bacon ex`.