### PR TITLE
fix middle click sending bacon to outer heaven 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### next
 - with `--headless`, bacon runs without TUI - Fix #293
 - `--config-toml` argument - Fix #284
+- fix workspace level Cargo.toml file not watched
 
 <a name="v3.7.0"></a>
 ### v3.7.0 - 2024/12/27

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -9,17 +9,15 @@ use {
     termimad::crossterm::{
         QueueableCommand,
         cursor,
+        event::{
+            DisableMouseCapture,
+            EnableMouseCapture,
+        },
         terminal::{
             EnterAlternateScreen,
             LeaveAlternateScreen,
         },
     },
-};
-
-#[cfg(windows)]
-use termimad::crossterm::event::{
-    DisableMouseCapture,
-    EnableMouseCapture,
 };
 /// The Write type used by all GUI writing functions
 pub type W = std::io::BufWriter<std::io::Stdout>;
@@ -85,13 +83,11 @@ pub fn run() -> anyhow::Result<()> {
     if !headless {
         w.queue(EnterAlternateScreen)?;
         w.queue(cursor::Hide)?;
-        #[cfg(windows)]
         w.queue(EnableMouseCapture)?;
         w.flush()?;
     }
     let result = app::run(&mut w, settings, &args, context, headless);
     if !headless {
-        #[cfg(windows)]
         w.queue(DisableMouseCapture)?;
         w.queue(cursor::Show)?;
         w.queue(LeaveAlternateScreen)?;


### PR DESCRIPTION
Fix #298 

The problem of middle-click is that it's used on linux (especially linux terminals) to send as key events the content of the clipboard.

This PR "solves" the problem by making bacon manage mouse events by itself.

With this PR, bacon scrolls up and down using the mouse wheel events.

Downsides:
- potential regression for users pasting with middle click into the search input
- **major** regression for users selecting and copying with the mouse
- not using the scroll multiplier defined OS wide

Given the downsides, this PR can't be merged right now.
I would need at least to manage selecting (which could be better that today's selection as it would handle the scrollbar correctly), but also replace the menu for copying that most terminals propose on right click.