### PR TITLE
Avoid freezes when reloading configs on macos

### DIFF
--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -22,8 +22,8 @@ use {
 
 /// A file watcher, providing a channel to receive notifications
 pub struct Watcher {
-    _notify_watcher: RecommendedWatcher,
     pub receiver: Receiver<()>,
+    _notify_watcher: RecommendedWatcher,
 }
 
 impl Watcher {
@@ -88,8 +88,8 @@ impl Watcher {
             }
         }
         Ok(Self {
-            _notify_watcher: notify_watcher,
             receiver,
+            _notify_watcher: notify_watcher,
         })
     }
 }


### PR DESCRIPTION
On macos reloading the config file results in a freeze, caused by <https://github.com/notify-rs/notify/issues/208>.

The freeze occurs when the watchers in `run_mission` are dropped while exiting from the function.

Reordering the fields so that `_notify_watcher` is dropped after `receiver` fixes the issue, although I'm unsure why.

At first I thought that the channel was being used by the notify watcher, which is why I tried the field reordering, I thought there was a dependency creating a deadlock. This isn't correct though; the notify watcher has its own thread that is being used for processing events, so I don't understand the interaction.

That said, it appears to be a reliable fix. Without this change the freeze occurs consistently, but with this change reloading the config never freezes.

Fixes #306.
