### PR TITLE
Make sure we can build the sound support with Nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -21,6 +21,7 @@
 
         naersk' = pkgs.callPackage naersk { };
         bacon = naersk'.buildPackage {
+          buildInputs = [ pkgs.alsa-lib pkgs.pkg-config ];
           src = ./.;
         };
       in


### PR DESCRIPTION
Bacon now requires pkg-config and alsa-lib to compile with Nix.