### PR TITLE
[Nix] Make sure we pull alsa and pkg only on Linux

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -21,6 +21,7 @@
 
         naersk' = pkgs.callPackage naersk { };
         bacon = naersk'.buildPackage {
+          buildInputs = [ pkgs.alsa-lib pkgs.pkg-config ];
           src = ./.;
         };
       in

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
 
         naersk' = pkgs.callPackage naersk { };
         bacon = naersk'.buildPackage {
-          buildInputs = [ pkgs.alsa-lib pkgs.pkg-config ];
+          buildInputs = if pkgs.stdenv.isLinux then [ pkgs.alsa-lib pkgs.pkg-config ] else [];
           src = ./.;
         };
       in


### PR DESCRIPTION
The dependency `rodio` requires alsa and pkgconfig only on Linux. My previous commit was breaking Nix build on other platforms 😞 

Apologies for the oversight.