### PR TITLE
All jobs config

### DIFF
--- a/defaults/default-prefs.toml
+++ b/defaults/default-prefs.toml
@@ -27,7 +27,7 @@
 # moves the file to a backup name before recreating the right one)
 # You can set it to "none" if it's useless for you.
 #
-# grace_period = "5ms"
+# grace_period = "15ms"
 
 
 # Uncomment and change the value (true/false) to

--- a/src/analysis/analyzer.rs
+++ b/src/analysis/analyzer.rs
@@ -9,7 +9,6 @@ use {
         standard,
     },
     crate::*,
-    anyhow::Result,
     serde::{
         Deserialize,
         Serialize,
@@ -64,5 +63,5 @@ pub trait Analyzer {
         command_output: &mut CommandOutput,
     );
 
-    fn build_report(&mut self) -> Result<Report>;
+    fn build_report(&mut self) -> anyhow::Result<Report>;
 }

--- a/src/analysis/line_pattern.rs
+++ b/src/analysis/line_pattern.rs
@@ -42,3 +42,12 @@ impl<'de> Deserialize<'de> for LinePattern {
         FromStr::from_str(&s).map_err(de::Error::custom)
     }
 }
+
+impl PartialEq for LinePattern {
+    fn eq(
+        &self,
+        other: &Self,
+    ) -> bool {
+        self.regex.as_str() == other.regex.as_str()
+    }
+}

--- a/src/app.rs
+++ b/src/app.rs
@@ -69,7 +69,7 @@ pub fn run(
                 break;
             }
         };
-        let mission = location.mission(concrete_job_ref, job, &settings)?;
+        let mission = location.mission(concrete_job_ref, &job, &settings)?;
         let do_after =
             app::run_mission(w, mission, event_source.as_ref(), message.take(), headless)?;
         match do_after {
@@ -102,7 +102,7 @@ fn run_mission(
     headless: bool,
 ) -> Result<DoAfterMission> {
     let keybindings = mission.settings.keybindings.clone();
-    let grace_period = mission.grace_period();
+    let grace_period = mission.job.grace_period();
 
     let sound_player = mission.sound_player_if_needed();
 
@@ -115,7 +115,7 @@ fn run_mission(
 
     // create the executor, mission, and state
     let mut executor = MissionExecutor::new(&mission)?;
-    let on_change_strategy = mission.on_change_strategy();
+    let on_change_strategy = mission.job.on_change_strategy();
     let mut state = AppState::new(mission, headless)?;
     if let Some(message) = message {
         state.messages.push(message);
@@ -290,6 +290,7 @@ fn run_mission(
                     Internal::Help => {
                         state.toggle_help();
                     }
+                    Internal::NoOp => {}
                     Internal::Pause => {
                         state.auto_refresh = AutoRefresh::Paused;
                     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -102,7 +102,7 @@ fn run_mission(
     headless: bool,
 ) -> Result<DoAfterMission> {
     let keybindings = mission.settings.keybindings.clone();
-    let grace_period = mission.settings.grace_period;
+    let grace_period = mission.grace_period();
 
     let sound_player = mission.sound_player_if_needed();
 
@@ -115,11 +115,7 @@ fn run_mission(
 
     // create the executor, mission, and state
     let mut executor = MissionExecutor::new(&mission)?;
-    let on_change_strategy = mission
-        .job
-        .on_change_strategy
-        .or(mission.settings.on_change_strategy)
-        .unwrap_or(OnChangeStrategy::WaitThenRestart);
+    let on_change_strategy = mission.on_change_strategy();
     let mut state = AppState::new(mission, headless)?;
     if let Some(message) = message {
         state.messages.push(message);

--- a/src/conf/config.rs
+++ b/src/conf/config.rs
@@ -21,13 +21,9 @@ pub struct Config {
 
     pub default_job: Option<ConcreteJobRef>,
 
-    /// Whether to apply the default watch list, which is
-    /// `["src", "tests", "benches", "examples", "build.rs"]`
-    ///
-    /// This is true by default. Set it to false if you want
-    /// to watch nothing, or only the directories you set in
-    /// `watch`.
-    pub default_watch: Option<bool>,
+    /// Default config for a job
+    #[serde(flatten)]
+    pub all_jobs: Job,
 
     /// locations export
     #[deprecated(since = "2.22.0", note = "use exports.locations")]
@@ -46,48 +42,20 @@ pub struct Config {
 
     pub help_line: Option<bool>,
 
-    /// A list of glob patterns to ignore
-    #[serde(default)]
-    pub ignore: Vec<String>,
-
-    /// Patterns of lines which should be ignored. Patterns of
-    /// the prefs or bacon.toml can be overridden at the job
-    pub ignored_lines: Option<Vec<LinePattern>>,
-
     #[serde(default)]
     pub jobs: HashMap<String, Job>,
 
     pub keybindings: Option<KeyBindings>,
 
-    pub on_change_strategy: Option<OnChangeStrategy>,
-
     pub reverse: Option<bool>,
 
-    pub show_changes_count: Option<bool>,
 
     pub summary: Option<bool>,
 
     #[deprecated(since = "2.0.0", note = "use keybindings")]
     pub vim_keys: Option<bool>,
 
-    /// A list of files and directories that will be watched if the job
-    /// is run on a package.
-    ///
-    /// src, examples, tests, benches, and build.rs are implicitly
-    /// included unless you `set default_watch` to false.
-    pub watch: Option<Vec<String>>,
-
     pub wrap: Option<bool>,
-
-    /// Env vars to set for all job executions
-    #[serde(default)]
-    pub env: HashMap<String, String>,
-
-    /// Whether to beep when the job ends
-    pub beep_on_end: Option<bool>,
-
-    #[serde(default)]
-    pub sound: SoundConfig,
 }
 
 impl Config {

--- a/src/conf/config.rs
+++ b/src/conf/config.rs
@@ -35,11 +35,6 @@ pub struct Config {
     #[serde(default)]
     pub exports: HashMap<String, ExportConfig>,
 
-    /// The delay between a file event and the real start of the
-    /// task. Other file events occuring during this period will be
-    /// ignored.
-    pub grace_period: Option<Period>,
-
     pub help_line: Option<bool>,
 
     #[serde(default)]
@@ -48,7 +43,6 @@ pub struct Config {
     pub keybindings: Option<KeyBindings>,
 
     pub reverse: Option<bool>,
-
 
     pub summary: Option<bool>,
 

--- a/src/conf/settings.rs
+++ b/src/conf/settings.rs
@@ -7,7 +7,6 @@ use {
     std::{
         collections::HashMap,
         path::PathBuf,
-        time::Duration,
     },
 };
 
@@ -54,6 +53,7 @@ impl Default for Settings {
             default_job: Default::default(),
             exports: Default::default(),
             config_files: Default::default(),
+            all_jobs: Default::default(),
         }
     }
 }

--- a/src/conf/settings.rs
+++ b/src/conf/settings.rs
@@ -24,24 +24,16 @@ pub struct Settings {
     /// (note that not all settings come from files)
     pub config_files: Vec<PathBuf>,
     pub default_job: ConcreteJobRef,
-    pub default_watch: bool,
     pub exports: ExportsSettings,
     pub features: Option<String>, // comma separated list
-    pub grace_period: Period,
     pub help_line: bool,
-    pub ignore: Vec<String>,
-    pub ignored_lines: Option<Vec<LinePattern>>,
     pub jobs: HashMap<String, Job>,
     pub keybindings: KeyBindings,
     pub no_default_features: bool,
-    pub on_change_strategy: Option<OnChangeStrategy>,
     pub reverse: bool,
-    pub show_changes_count: bool,
     pub summary: bool,
-    pub watch: Vec<String>,
     pub wrap: bool,
-    pub env: HashMap<String, String>,
-    pub sound: SoundConfig,
+    pub all_jobs: Job,
 }
 
 impl Default for Settings {
@@ -61,16 +53,7 @@ impl Default for Settings {
             jobs: Default::default(),
             default_job: Default::default(),
             exports: Default::default(),
-            show_changes_count: false,
-            on_change_strategy: None,
-            ignore: Default::default(),
-            ignored_lines: Default::default(),
-            grace_period: Duration::from_millis(5).into(),
             config_files: Default::default(),
-            default_watch: true,
-            watch: Default::default(),
-            env: Default::default(),
-            sound: Default::default(),
         }
     }
 }
@@ -150,7 +133,7 @@ impl Settings {
         &mut self,
         config: &Config,
     ) {
-        self.env.extend(config.env.clone());
+        self.all_jobs.apply(&config.all_jobs);
         if let Some(b) = config.summary {
             self.summary = b;
         }
@@ -181,28 +164,6 @@ impl Settings {
             self.default_job = default_job.clone();
         }
         self.exports.apply_config(config);
-        if let Some(b) = config.show_changes_count {
-            self.show_changes_count = b;
-        }
-        if let Some(b) = config.on_change_strategy {
-            self.on_change_strategy = Some(b);
-        }
-        if let Some(b) = config.ignored_lines.as_ref() {
-            self.ignored_lines = Some(b.clone());
-        }
-        if let Some(p) = config.grace_period {
-            self.grace_period = p;
-        }
-        if let Some(b) = config.default_watch {
-            self.default_watch = b;
-        }
-        if let Some(watch) = config.watch.as_ref() {
-            self.watch = watch.clone();
-        }
-        for pattern in &config.ignore {
-            self.ignore.push(pattern.clone());
-        }
-        self.sound.apply(&config.sound);
     }
     pub fn apply_args(
         &mut self,

--- a/src/context.rs
+++ b/src/context.rs
@@ -144,14 +144,17 @@ impl Context {
             // Automatically watch all kinds of source files.
             // "watches", at this point, aren't full path, they still must be joined
             // with the right path which may depend on the
-            let mut watches: Vec<&str> = job
-                .watch
-                .as_ref()
-                .unwrap_or(&settings.watch)
-                .iter()
-                .map(|s| s.as_str())
-                .collect();
-            let add_default = job.default_watch.unwrap_or(settings.default_watch);
+
+            let mut watches = Vec::new();
+            for watch in settings.watch.iter() {
+                watches.push(watch.as_str());
+            }
+            for watch in job.watch.iter() {
+                watches.push(watch.as_str());
+            }
+            let add_default = job.default_watch
+                .or(settings.all_jobs.default_watch)
+                .unwrap_or(true);
             if add_default {
                 for watch in DEFAULT_WATCHES {
                     if !watches.contains(watch) {

--- a/src/context.rs
+++ b/src/context.rs
@@ -133,9 +133,14 @@ impl Context {
     pub fn mission<'s>(
         &self,
         concrete_job_ref: ConcreteJobRef,
-        job: Job,
+        leaf_job: &Job, // the raw job as defined, without using root settings
         settings: &'s Settings,
     ) -> Result<Mission<'s>> {
+        // the real job used in the mission is built from settings.all_jobs
+        // on which the provided leaf job is applied
+        let mut job = settings.all_jobs.clone();
+        job.apply(leaf_job);
+
         let location_name = self.name.clone();
         let mut paths_to_watch: Vec<PathBuf> = Vec::new();
         if let Some(path_to_watch) = &self.path_to_watch {
@@ -144,17 +149,13 @@ impl Context {
             // Automatically watch all kinds of source files.
             // "watches", at this point, aren't full path, they still must be joined
             // with the right path which may depend on the
-
             let mut watches = Vec::new();
-            for watch in settings.watch.iter() {
-                watches.push(watch.as_str());
+            if let Some(v) = &job.watch {
+                for watch in v.iter() {
+                    watches.push(watch.as_str());
+                }
             }
-            for watch in job.watch.iter() {
-                watches.push(watch.as_str());
-            }
-            let add_default = job.default_watch
-                .or(settings.all_jobs.default_watch)
-                .unwrap_or(true);
+            let add_default = job.default_watch.unwrap_or(true);
             if add_default {
                 for watch in DEFAULT_WATCHES {
                     if !watches.contains(watch) {

--- a/src/exec/executor.rs
+++ b/src/exec/executor.rs
@@ -76,7 +76,7 @@ impl TaskExecutor {
 impl MissionExecutor {
     /// Prepare the executor (no task/process/thread is started at this point)
     pub fn new(mission: &Mission) -> anyhow::Result<Self> {
-        let command_builder = mission.get_command();
+        let command_builder = mission.get_command()?;
         let kill_command = mission.kill_command();
         let (line_sender, line_receiver) = channel::unbounded();
         Ok(Self {

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -26,7 +26,11 @@ pub enum Internal {
     CopyUnstyledOutput,
     FocusSearch,
     Help,
+    NextMatch,
+    NoOp, // no operation, can be used to clear a binding
     Pause,
+    PlaySound(PlaySoundCommand),
+    PreviousMatch,
     Quit,
     ReRun,
     Refresh, // clear and rerun
@@ -40,10 +44,6 @@ pub enum Internal {
     ToggleWrap,
     Unpause,
     Validate, // validate search entry
-    NextMatch,
-    PreviousMatch,
-    PlaySound(PlaySoundCommand),
-    NoOp, // no operation, can be used to clear a binding
 }
 
 impl Internal {
@@ -52,8 +52,13 @@ impl Internal {
         match self {
             Self::Back => "back to previous page or job".to_string(),
             Self::CopyUnstyledOutput => "copy current job's output".to_string(),
+            Self::FocusSearch => "focus search".to_string(),
             Self::Help => "help".to_string(),
+            Self::NextMatch => "next match".to_string(),
+            Self::NoOp => "no operation".to_string(),
             Self::Pause => "pause".to_string(),
+            Self::PlaySound(_) => "play sound".to_string(),
+            Self::PreviousMatch => "previous match".to_string(),
             Self::Quit => "quit".to_string(),
             Self::ReRun => "run current job again".to_string(),
             Self::Refresh => "clear then run current job again".to_string(),
@@ -66,11 +71,7 @@ impl Internal {
             Self::ToggleSummary => "toggle summary".to_string(),
             Self::ToggleWrap => "toggle wrap".to_string(),
             Self::Unpause => "unpause".to_string(),
-            Self::FocusSearch => "focus search".to_string(),
             Self::Validate => "validate".to_string(),
-            Self::NextMatch => "next match".to_string(),
-            Self::PreviousMatch => "previous match".to_string(),
-            Self::PlaySound(_) => "play sound".to_string(),
         }
     }
 }
@@ -84,6 +85,7 @@ impl fmt::Display for Internal {
             Self::Back => write!(f, "back"),
             Self::CopyUnstyledOutput => write!(f, "copy-unstyled-output"),
             Self::Help => write!(f, "help"),
+            Self::NoOp => write!(f, "no-op"),
             Self::Pause => write!(f, "pause"),
             Self::Quit => write!(f, "quit"),
             Self::ReRun => write!(f, "rerun"),
@@ -132,6 +134,7 @@ impl std::str::FromStr for Internal {
             "toggle-backtrace(full)" => Ok(Self::ToggleBacktrace("full")),
             "toggle-summary" => Ok(Self::ToggleSummary),
             "toggle-wrap" => Ok(Self::ToggleWrap),
+            "noop" | "no-op" | "no-operation" => Ok(Self::NoOp),
             "pause" => Ok(Self::Pause),
             "unpause" => Ok(Self::Unpause),
             "toggle-pause" => Ok(Self::TogglePause),
@@ -194,6 +197,7 @@ fn test_internal_string_round_trip() {
         Internal::Back,
         Internal::FocusSearch,
         Internal::Help,
+        Internal::NoOp,
         Internal::Pause,
         Internal::Quit,
         Internal::ReRun,

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -43,6 +43,7 @@ pub enum Internal {
     NextMatch,
     PreviousMatch,
     PlaySound(PlaySoundCommand),
+    NoOp, // no operation, can be used to clear a binding
 }
 
 impl Internal {

--- a/src/jobs/job.rs
+++ b/src/jobs/job.rs
@@ -33,8 +33,7 @@ pub struct Job {
 
     /// The tokens making the command to execute (first one
     /// is the executable).
-    /// This vector is guaranteed not empty
-    /// by the PackageConfig::from_path loader
+    #[serde(default)]
     pub command: Vec<String>,
 
     /// Whether to apply the default watch list, which is
@@ -46,6 +45,7 @@ pub struct Job {
     pub default_watch: Option<bool>,
 
     /// Env vars to set for this job execution
+    #[serde(default)]
     pub env: HashMap<String, String>,
 
     /// Whether to expand environment variables in the command
@@ -127,27 +127,38 @@ impl Job {
             ..Default::default()
         }
     }
-    //pub fn allow_failures(&self) -> bool {
-    //    self.allow_failures.unwrap_or(false)
-    //}
-    //pub fn allow_warnings(&self) -> bool {
-    //    self.allow_warnings.unwrap_or(false)
-    //}
-    //pub fn background(&self) -> bool {
-    //    self.background.unwrap_or(true)
-    //}
-    //pub fn default_watch(&self) -> bool {
-    //    self.default_watch.unwrap_or(true)
-    //}
-    //pub fn need_stdout(&self) -> bool {
-    //    self.need_stdout.unwrap_or(false)
-    //}
-    //pub fn extraneous_args(&self) -> bool {
-    //    self.extraneous_args.unwrap_or(true)
-    //}
-    //pub fn show_changes_count(&self) -> bool {
-    //    self.show_changes_count.unwrap_or(false)
-    //}
+    pub fn allow_failures(&self) -> bool {
+        self.allow_failures.unwrap_or(false)
+    }
+    pub fn allow_warnings(&self) -> bool {
+        self.allow_warnings.unwrap_or(false)
+    }
+    pub fn background(&self) -> bool {
+        self.background.unwrap_or(true)
+    }
+    pub fn default_watch(&self) -> bool {
+        self.default_watch.unwrap_or(true)
+    }
+    pub fn expand_env_vars(&self) -> bool {
+        self.expand_env_vars.unwrap_or(true)
+    }
+    pub fn need_stdout(&self) -> bool {
+        self.need_stdout.unwrap_or(false)
+    }
+    pub fn extraneous_args(&self) -> bool {
+        self.extraneous_args.unwrap_or(true)
+    }
+    pub fn show_changes_count(&self) -> bool {
+        self.show_changes_count.unwrap_or(false)
+    }
+    pub fn grace_period(&self) -> Period {
+        self.grace_period
+            .unwrap_or(std::time::Duration::from_millis(15).into())
+    }
+    pub fn on_change_strategy(&self) -> OnChangeStrategy {
+        self.on_change_strategy
+            .unwrap_or(OnChangeStrategy::WaitThenRestart)
+    }
     pub fn apply(
         &mut self,
         job: &Job,
@@ -158,8 +169,8 @@ impl Job {
         if let Some(b) = job.allow_warnings {
             self.allow_warnings = Some(b);
         }
-        if let Some(v) = job.analyzer.as_ref() {
-            self.analyzer = Some(v.clone());
+        if let Some(v) = job.analyzer {
+            self.analyzer = Some(v);
         }
         if let Some(b) = job.apply_gitignore {
             self.apply_gitignore = Some(b);
@@ -187,10 +198,8 @@ impl Job {
                 self.ignore.push(v.clone());
             }
         }
-        for v in &job.ignored_lines {
-            if let Some(v) = v.as_ref() {
-                self.ignored_lines = Some(v.clone());
-            }
+        if let Some(v) = job.ignored_lines.as_ref() {
+            self.ignored_lines = Some(v.clone());
         }
         if let Some(v) = job.kill.as_ref() {
             self.kill = Some(v.clone());
@@ -198,8 +207,8 @@ impl Job {
         if let Some(b) = job.need_stdout {
             self.need_stdout = Some(b);
         }
-        if let Some(v) = job.on_change_strategy.as_ref() {
-            self.on_change_strategy = Some(v.clone());
+        if let Some(v) = job.on_change_strategy {
+            self.on_change_strategy = Some(v);
         }
         if let Some(v) = job.on_success.as_ref() {
             self.on_success = Some(v.clone());
@@ -214,6 +223,5 @@ impl Job {
             self.show_changes_count = Some(b);
         }
         self.sound.apply(&job.sound);
-
     }
 }

--- a/src/mission.rs
+++ b/src/mission.rs
@@ -244,6 +244,17 @@ impl Mission<'_> {
             None
         }
     }
+
+    pub fn grace_period(&self) -> Period {
+        self.job.grace_period
+            .or(self.settings.all_jobs.grace_period)
+            .unwrap_or_else(|| std::time::Duration::from_millis(15).into())
+    }
+    pub fn on_change_strategy(&self) -> OnChangeStrategy {
+        self.job.on_change_strategy
+            .or(self.settings.all_jobs.on_change_strategy)
+            .unwrap_or(OnChangeStrategy::WaitThenRestart)
+    }
 }
 
 fn merge_features(

--- a/src/sound/sound_config.rs
+++ b/src/sound/sound_config.rs
@@ -3,7 +3,7 @@ use {
     serde::Deserialize,
 };
 
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Default, Deserialize, PartialEq)]
 pub struct SoundConfig {
     pub enabled: Option<bool>,
     pub base_volume: Option<Volume>,

--- a/src/state.rs
+++ b/src/state.rs
@@ -123,7 +123,7 @@ impl<'s> AppState<'s> {
             wrap: mission.settings.wrap,
             backtrace: None,
             reverse: mission.settings.reverse,
-            show_changes_count: mission.settings.show_changes_count,
+            show_changes_count: mission.job.show_changes_count(),
             status_skin,
             scroll: 0,
             top_item_idx: 0,
@@ -307,7 +307,7 @@ impl<'s> AppState<'s> {
     pub fn new_task(&self) -> Task {
         Task {
             backtrace: self.backtrace,
-            grace_period: self.mission.settings.grace_period,
+            grace_period: self.mission.job.grace_period(),
         }
     }
     pub fn take_output(&mut self) -> Option<CommandOutput> {
@@ -419,7 +419,7 @@ impl<'s> AppState<'s> {
     }
     /// Called when a task has started
     pub fn computation_starts(&mut self) {
-        if !self.mission.job.background {
+        if !self.mission.job.background() {
             self.clear();
         }
         self.report_maker.start(&self.mission);

--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -93,7 +93,7 @@ on_change_strategy | `wait_then_restart` or `kill_then_restart` |
 on_success | the action to run when there's no error, warning or test failures |
 watch | a list of files and directories that will be watched if the job is run on a package. Usual source directories are implicitly included unless `default_watch` is set to false |
 
-Some of these properties can also be defined before jobs and will apply to all of them unless overriden: `watch`, `default_watch`, `ignore` (additive), `ignored_lines`, and `on_change_strategy`.
+All these properties can also be defined before jobs and will apply to all of them unless overriden.
 
 Beware of job references in `on_success`: you must avoid loops with 2 jobs calling themselves mutually, which would make bacon run all the time.
 
@@ -305,7 +305,7 @@ You can change the `summary`, `wrapping`, and `reverse` mode at launch (see `bac
 
 You may have audio notifications on job success or failures.
 
-This requires sound to be enabled:
+This requires sound to be enabled, either at root level or in a specific job:
 
 ```TOML
 [sound]


### PR DESCRIPTION
This refactors job settings:

* allow some settings which were only allowed at root to be also at the job level (for example grace_period, or sound)
* allow some settings which were only allowed inside jobs to be also at the root
* remove the duplication of settings which were defined both in `Job` and in `Config` (and sometimes also in `Settings`)

Now, *all* parameters of a job can also be defined at root level (which means that a job definition can theoretically be empty).