### PR TITLE
docs: fix typos

### DIFF
--- a/bacon.toml
+++ b/bacon.toml
@@ -9,7 +9,7 @@ env.CARGO_TERM_COLOR = "always"
 
 [jobs]
 
-# This alternative to 'check' demontrates the use of the JSON output
+# This alternative to 'check' demonstrates the use of the JSON output
 # of cargo check - see https://github.com/Canop/bacon/issues/249
 [jobs.json-check]
 command = [

--- a/defaults/default-prefs.toml
+++ b/defaults/default-prefs.toml
@@ -23,7 +23,7 @@
 # The grace period is a delay after a file event before the real
 # task is launched and during which other events will be ignored.
 # This is mostly useful when your editor does several operations
-# when saving a file and the state is temporarly wrong (eg it
+# when saving a file and the state is temporarily wrong (eg it
 # moves the file to a backup name before recreating the right one)
 # You can set it to "none" if it's useless for you.
 #

--- a/src/conf/settings.rs
+++ b/src/conf/settings.rs
@@ -79,7 +79,7 @@ impl Settings {
     /// Read the settings from all configuration files and arguments.
     ///
     ///
-    /// Hardcoded defaults are overriden by the following configuration elements, in order:
+    /// Hardcoded defaults are overridden by the following configuration elements, in order:
     /// * the default `bacon.toml` file (embedded in the binary)
     /// * the global `prefs.toml`, from user config directory
     /// * the file whose path is in environment variable `BACON_PREFS`

--- a/src/jobs/job.rs
+++ b/src/jobs/job.rs
@@ -4,7 +4,7 @@ use {
     std::collections::HashMap,
 };
 
-/// One of the possible job that bacon can run
+/// One of the possible jobs that bacon can run
 #[derive(Debug, Clone, Deserialize)]
 pub struct Job {
     /// Whether to consider that we can have a success

--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -93,7 +93,7 @@ on_change_strategy | `wait_then_restart` or `kill_then_restart` |
 on_success | the action to run when there's no error, warning or test failures |
 watch | a list of files and directories that will be watched if the job is run on a package. Usual source directories are implicitly included unless `default_watch` is set to false |
 
-Some of these properties can also be defined before jobs and will apply to all of them unless overriden: `watch`, `default_watch`, `ignore` (additive), `ignored_lines`, and `on_change_strategy`.
+Some of these properties can also be defined before jobs and will apply to all of them unless overridden: `watch`, `default_watch`, `ignore` (additive), `ignored_lines`, and `on_change_strategy`.
 
 Beware of job references in `on_success`: you must avoid loops with 2 jobs calling themselves mutually, which would make bacon run all the time.
 
@@ -106,7 +106,7 @@ need_stdout = true
 ```
 
 Note: Some tools detect that their output is piped and don't add style information unless you add a parameter which usually looks like `--color always`.
-This isn't normally necessary for cargo because bacon, by default, sets the `CARGO_TERM_COLOR` environnment variable.
+This isn't normally necessary for cargo because bacon, by default, sets the `CARGO_TERM_COLOR` environment variable.
 
 ## Analyzers
 
@@ -246,7 +246,7 @@ This export works for any tool and any job.
 
 ## Cargo Spans export
 
-When using the `cargo_json` analyzer, more detailed informations are available than what's printed on screen and this analyzer can provide those data with a configuration such as this one:
+When using the `cargo_json` analyzer, more detailed information is available than what is printed on screen and this analyzer can provide that data with a configuration such as this one:
 
 ```TOML
 [jobs.bacon-ls]
@@ -320,4 +320,4 @@ on_success = "play-sound(name=90s-game-ui-6,volume=50)"
 on_failure = "play-sound(name=beep-warning,volume=100)"
 ```
 
-Sound name can be ommited. Possible values are `2`, `90s-game-ui-6`, `beep-6`, `beep-beep`, `beep-warning`, `bell-chord`, `car-horn`, `convenience-store-ring`, `cow-bells`, `pickup`, `positive-beeps`, `short-beep-tone`, `slash`, `store-scanner`, `success`.
+Sound name can be omitted. Possible values are `2`, `90s-game-ui-6`, `beep-6`, `beep-beep`, `beep-warning`, `bell-chord`, `car-horn`, `convenience-store-ring`, `cow-bells`, `pickup`, `positive-beeps`, `short-beep-tone`, `slash`, `store-scanner`, `success`.


### PR DESCRIPTION
A few typos noticed while reviewing the code