### PR TITLE
implement dynamic completions for jobs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,6 +176,7 @@ dependencies = [
  "cargo_metadata",
  "clap",
  "clap-help",
+ "clap_complete",
  "cli-log",
  "crokey",
  "ctrlc",
@@ -389,6 +390,18 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+]
+
+[[package]]
+name = "clap_complete"
+version = "4.5.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "375f9d8255adeeedd51053574fd8d4ba875ea5fa558e86617b07f09f1680c8b6"
+dependencies = [
+ "clap",
+ "clap_lex",
+ "is_executable",
+ "shlex",
 ]
 
 [[package]]
@@ -1589,6 +1602,15 @@ dependencies = [
  "lazy-regex",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "is_executable"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4a1b5bad6f9072935961dfbf1cced2f3d129963d091b6f69f007fe04e758ae2"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ arboard = { version = "3.4", default-features = false, optional = true }
 cargo_metadata = "0.19"
 clap = { version = "4.5", features = ["derive", "cargo"] }
 clap-help = "1.3"
+clap_complete = { version = "4.5.44", features = ["unstable-dynamic"] }
 cli-log = "2.1"
 crokey = "1.1"
 ctrlc = "3.4"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,10 @@
 use {
     crate::*,
     anyhow::anyhow,
-    clap::Parser,
+    clap::{
+        CommandFactory,
+        Parser,
+    },
     std::{
         fs,
         io::Write,
@@ -21,6 +24,9 @@ use termimad::crossterm::event::{
     DisableMouseCapture,
     EnableMouseCapture,
 };
+
+pub mod completions;
+
 /// The Write type used by all GUI writing functions
 pub type W = std::io::BufWriter<std::io::Stdout>;
 
@@ -30,6 +36,10 @@ pub fn writer() -> W {
 }
 
 pub fn run() -> anyhow::Result<()> {
+    if std::env::var_os("COMPLETE").is_some() {
+        clap_complete::CompleteEnv::with_factory(Args::command).complete();
+    }
+
     let mut args: Args = Args::parse();
     args.fix()?;
     info!("args: {:#?}", &args);
@@ -78,6 +88,12 @@ pub fn run() -> anyhow::Result<()> {
 
     if args.list_jobs {
         print_jobs(&settings);
+        return Ok(());
+    }
+    if args.completion_list_jobs {
+        for job in settings.jobs.keys() {
+            print!("{job}\0");
+        }
         return Ok(());
     }
 

--- a/src/cli/completions.rs
+++ b/src/cli/completions.rs
@@ -1,0 +1,21 @@
+use {
+    clap_complete::CompletionCandidate,
+    std::process::Command,
+};
+
+fn with_self_command(
+    f: impl FnOnce(Command) -> Option<Vec<CompletionCandidate>>
+) -> Vec<CompletionCandidate> {
+    std::env::current_exe()
+        .ok()
+        .and_then(|command| f(Command::new(command)))
+        .unwrap_or_default()
+}
+
+pub fn list_jobs() -> Vec<CompletionCandidate> {
+    with_self_command(|mut c| {
+        let output = c.arg("--completion-list-jobs").output().ok()?;
+        let output: String = String::from_utf8(output.stdout).ok()?;
+        Some(output.split('\0').map(CompletionCandidate::new).collect())
+    })
+}

--- a/src/conf/args.rs
+++ b/src/conf/args.rs
@@ -123,11 +123,11 @@ pub struct Args {
 
     /// Path to watch (overriding what's normally computed from the project's
     /// type, bacon.toml file, etc.)
-    #[clap(long, value_name = "watch")]
+    #[clap(long, value_name = "watch", value_hint = clap::ValueHint::FilePath)]
     pub watch: Option<String>,
 
     /// Project to run jobs on, and use as working directory
-    #[clap(long, value_name = "project")]
+    #[clap(long, value_name = "project", value_hint = clap::ValueHint::DirPath)]
     pub project: Option<String>,
 
     /// Configuration passed as a TOML string

--- a/src/conf/args.rs
+++ b/src/conf/args.rs
@@ -8,6 +8,7 @@ use {
         CommandFactory,
         Parser,
     },
+    clap_complete::ArgValueCandidates,
     termimad::ansi,
 };
 
@@ -84,6 +85,8 @@ pub struct Args {
     /// List available jobs
     #[clap(short = 'l', long)]
     pub list_jobs: bool,
+    #[clap(long, hide = true)]
+    pub completion_list_jobs: bool,
 
     /// Don't access the network
     #[clap(long)]
@@ -94,7 +97,7 @@ pub struct Args {
     pub init: bool,
 
     /// Job to launch: `check`, `clippy`, custom ones...
-    #[clap(short = 'j', long, value_name = "job")]
+    #[clap(short = 'j', long, value_name = "job", add = ArgValueCandidates::new(crate::cli::completions::list_jobs))]
     pub job: Option<ConcreteJobRef>,
 
     /// Ignore features of both the package and the bacon job
@@ -131,7 +134,7 @@ pub struct Args {
     #[clap(long)]
     pub config_toml: Option<String>,
 
-    #[clap()]
+    #[clap(add = ArgValueCandidates::new(crate::cli::completions::list_jobs))]
     /// What to do: either a job, or a path, or both
     pub args: Vec<String>,
 


### PR DESCRIPTION
Implements dynamic completions using <https://docs.rs/clap_complete/latest/clap_complete/>. Use with, e.g. `COMPLETE=fish bacon | source`.

Allows you to complete job names. Example: `bacon <TAB>` ->
![image](https://github.com/user-attachments/assets/6697ca97-f580-4138-b973-038cfba97006)

Currently marked as draft because this does not resolve directory arguments, i.e. `bacon subdir/ <TAB>` will *not* read `subdir/bacon.toml`.