### PR TITLE
fix invalid spans for errors from proc-macros (#332)

### DIFF
--- a/src/analysis/cargo_json/cargo_json_export.rs
+++ b/src/analysis/cargo_json/cargo_json_export.rs
@@ -38,7 +38,14 @@ impl CargoJsonExport {
         diagnostic: &Diagnostic,
     ) {
         for span in &diagnostic.spans {
-            let data = OnSpanData { diagnostic, span };
+            let data = {
+                // This is a diagnostic that originates from a proc-macro.
+                if let Some(expansion) = &span.expansion {
+                    OnSpanData { diagnostic, span: &expansion.span }
+                } else {
+                    OnSpanData { diagnostic, span }
+                }
+            };
             let line = self.line_template.render(&data);
             if !line.is_empty() {
                 self.export.push_str(&line);


### PR DESCRIPTION
Proc macro diagnostics have a slightly different format since the diagnostic not only points out where the diagnostic is originating from but also where the macro is defined.

Fix #332 