### PR TITLE
Upgrade vte to 0.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,12 +151,6 @@ checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
 name = "arrayvec"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
-
-[[package]]
-name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
@@ -2469,7 +2463,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "798306779e3dc7d5231bd5691f5a813496dc79d3f56bf82e25789f2094e022c3"
 dependencies = [
- "arrayvec 0.7.6",
+ "arrayvec",
  "bitflags 1.3.2",
  "bytemuck",
  "lazy_static",
@@ -2732,23 +2726,12 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vte"
-version = "0.8.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96cc8a191608603611e78c6ec11dafef37e3cca0775aeef1931824753e81711d"
+checksum = "a5924018406ce0063cd67f8e008104968b74b563ee1b85dde3ed1f7cb87d3dbd"
 dependencies = [
- "arrayvec 0.5.2",
- "utf8parse",
- "vte_generate_state_changes",
-]
-
-[[package]]
-name = "vte_generate_state_changes"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e369bee1b05d510a7b4ed645f5faa90619e05437111783ea5848f28d97d3c2e"
-dependencies = [
- "proc-macro2",
- "quote",
+ "arrayvec",
+ "memchr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ serde_json = "1.0"
 termimad = "0.31.1"
 toml = "0.8"
 unicode-width = "0.2"
-vte = "0.8"
+vte = "0.15"
 
 [profile.release]
 debug = false

--- a/src/tty/tline_builder.rs
+++ b/src/tty/tline_builder.rs
@@ -12,9 +12,7 @@ impl TLineBuilder {
         s: &str,
     ) {
         let mut parser = vte::Parser::new();
-        for byte in s.bytes() {
-            parser.advance(self, byte);
-        }
+        parser.advance(self, s.as_bytes());
     }
     pub fn build(mut self) -> TLine {
         self.take_tstring();
@@ -49,12 +47,12 @@ impl vte::Perform for TLineBuilder {
     }
     fn csi_dispatch(
         &mut self,
-        params: &[i64],
+        params: &vte::Params,
         _intermediates: &[u8],
         _ignore: bool,
         action: char,
     ) {
-        if *params == [0] {
+        if params.len() == 1 && params.iter().next() == Some(&[0]) {
             self.take_tstring();
             return;
         }
@@ -76,7 +74,7 @@ impl vte::Perform for TLineBuilder {
     }
     fn hook(
         &mut self,
-        _params: &[i64],
+        _params: &vte::Params,
         _intermediates: &[u8],
         _ignore: bool,
         _action: char,

--- a/src/tty/tstring.rs
+++ b/src/tty/tstring.rs
@@ -65,13 +65,15 @@ impl TString {
     }
     pub fn push_csi(
         &mut self,
-        params: &[i64],
+        params: &vte::Params,
         action: char,
     ) {
         self.csi.push('\u{1b}');
         self.csi.push('[');
-        for (idx, p) in params.iter().enumerate() {
-            let _ = write!(self.csi, "{}", p);
+        for (idx, param) in params.iter().enumerate() {
+            for (_, p) in param.iter().enumerate() {
+                let _ = write!(self.csi, "{}", p);
+            }
             if idx < params.len() - 1 {
                 self.csi.push(';');
             }


### PR DESCRIPTION
This is mainly for packaging bacon in Debian, where vte is 0.13. (0.15 only additionally requires the bytes change for `Parser::advance()`, so it's an easy patch.)

I'm not sure if the changes are right though, can't see from tests or running it, so a review is necessary and appreciated.

vte gained CSI subparameter support in [0.9](https://github.com/alacritty/vte/blob/master/CHANGELOG.md#090), passing [`vte::Params`](https://docs.rs/vte/0.15.0/vte/struct.Params.html) in place of old `[i16]`. `Params::iter()` gives an iterator (`ParamsIter`), each `Item` of which is a `[u16]`, consisting of the "main" parameter and its subparameters.

For `if *params == [0]`, I assumed it means there's only one parameter, of the value 0, so for the iterator form I changed it to check if there's only one item and it's `[0]`.

For `TString::push_csi()`, the old cold just plain writes all parameters in the order they were received, so I iterated through the new items and write their parameters in order as well.