### PR TITLE
feat!: Add "back-or-quit" and don't quit on "back"

### DIFF
--- a/src/conf/action.rs
+++ b/src/conf/action.rs
@@ -142,6 +142,7 @@ fn test_action_string_round_trip() {
     let actions = vec![
         Action::Job(JobRef::Default),
         Action::Job(JobRef::Initial),
+        Action::Job(JobRef::PreviousOrQuit),
         Action::Job(JobRef::Previous),
         Action::Job(JobRef::Concrete(ConcreteJobRef {
             name_or_alias: NameOrAlias::Name("run".to_string()),

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -22,7 +22,8 @@ use {
 /// to a key or ran after a successful job
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Internal {
-    Back, // leave help, clear search, go to previous job, leave, etc.
+    Back,       // leave help, clear search, go to previous job, leave, etc.
+    BackOrQuit, // same as Back but quits if there is nothing to go back to
     CopyUnstyledOutput,
     FocusSearch,
     FocusGoto,
@@ -52,6 +53,9 @@ impl Internal {
     pub fn doc(&self) -> String {
         match self {
             Self::Back => "back to previous page or job".to_string(),
+            Self::BackOrQuit => {
+                "back to previous page or job, quitting if there is none".to_string()
+            }
             Self::CopyUnstyledOutput => "copy current job's output".to_string(),
             Self::FocusSearch => "focus search".to_string(),
             Self::FocusGoto => "focus goto".to_string(),
@@ -85,6 +89,7 @@ impl fmt::Display for Internal {
     ) -> fmt::Result {
         match self {
             Self::Back => write!(f, "back"),
+            Self::BackOrQuit => write!(f, "back-or-quit"),
             Self::CopyUnstyledOutput => write!(f, "copy-unstyled-output"),
             Self::Help => write!(f, "help"),
             Self::NoOp => write!(f, "no-op"),
@@ -124,6 +129,7 @@ impl std::str::FromStr for Internal {
         }
         match s {
             "back" => Ok(Self::Back),
+            "back-or-quit" => Ok(Self::BackOrQuit),
             "help" => Ok(Self::Help),
             "quit" => Ok(Self::Quit),
             "refresh" => Ok(Self::Refresh),
@@ -200,6 +206,7 @@ fn test_internal_string_round_trip() {
     use crate::Volume;
     let internals = [
         Internal::Back,
+        Internal::BackOrQuit,
         Internal::FocusSearch,
         Internal::Help,
         Internal::NoOp,

--- a/src/jobs/job_ref.rs
+++ b/src/jobs/job_ref.rs
@@ -9,6 +9,7 @@ pub enum JobRef {
     Default,
     Initial,
     Previous,
+    PreviousOrQuit,
     Concrete(ConcreteJobRef),
     Scope(Scope),
 }
@@ -46,6 +47,7 @@ impl fmt::Display for JobRef {
             Self::Default => write!(f, "default"),
             Self::Initial => write!(f, "initial"),
             Self::Previous => write!(f, "previous"),
+            Self::PreviousOrQuit => write!(f, "previous-or-quit"),
             Self::Scope(Scope { tests }) => write!(f, "scope:{}", tests.join(",")),
             Self::Concrete(concrete) => write!(f, "{}", concrete),
         }
@@ -58,6 +60,7 @@ impl From<&str> for JobRef {
             "^default$"i => Self::Default,
             "^initial$"i => Self::Initial,
             "^previous$"i => Self::Previous,
+            "^previous-or-quit$"i => Self::PreviousOrQuit,
             "^scope:(?<tests>.+)$"i => Self::Scope(Scope {
                 tests: tests
                     .split(',')
@@ -76,6 +79,7 @@ fn test_job_ref_string_round_trip() {
         JobRef::Default,
         JobRef::Initial,
         JobRef::Previous,
+        JobRef::PreviousOrQuit,
         JobRef::Concrete(ConcreteJobRef {
             name_or_alias: NameOrAlias::Name("run".to_string()),
             scope: Scope::default(),

--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -172,6 +172,7 @@ An export action is defined as `export:` followed by the export name.
 internal | default binding | meaning
 :-|:-|:-
 back | <kbd>Esc</kbd> | get back to the previous page or job, or cancel search
+back-or-quit | | back to previous page or job, quitting if there is none
 copy-unstyled-output | | write the currently displayed job output to the clipboard
 focus-search | <kbd>/</kbd> | focus the search input
 help | <kbd>h</kbd> or <kbd>?</kbd> | open the help page
@@ -222,7 +223,8 @@ job reference | meaning
 -|-
 `job:default` | the job defined as *default* in the bacon.toml file
 `job:initial` | the job specified as argument, or the default one if there was none explicit
-`job:previous` | the job which ran before, if any (or we would quit). The `back` internal has usually the same effect
+`job:previous` | the job which ran before, if any. The `back` internal has usually the same effect
+`job:previous-or-quit` | same as `job:previous`, but will quit if there was no job. The `back-or-quit` internal has usually the same effect
 
 # Exports
 


### PR DESCRIPTION
Closes #338 

This could be considered a "breaking" change since user-defined keybindings behave differently, as do the builtin defaults.

The new default "back" action no longer quits, and there is a new "back-or-quit" which restores the old behavior.

This also by nature makes the same change for job refs: "previous" no longer quits automatically but "previous-or-quit" does.