### PR TITLE
Implement custom sounds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,6 +168,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "shellexpand",
  "termimad",
  "toml",
  "unicode-width 0.2.2",
@@ -731,6 +732,27 @@ checksum = "339ee130d97a610ea5a5872d2bbb130fdf68884ff09d3028b81bec8a1ac23bbc"
 dependencies = [
  "cfg-if",
  "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2294,6 +2316,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2671,6 +2699,15 @@ name = "shell-words"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
+
+[[package]]
+name = "shellexpand"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da03fa3b94cc19e3ebfc88c4229c49d8f08cdbd1228870a45f0ffdf84988e14b"
+dependencies = [
+ "dirs",
+]
 
 [[package]]
 name = "shlex"
@@ -3266,6 +3303,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
@@ -3304,6 +3350,21 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -3347,6 +3408,12 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -3365,6 +3432,12 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -3380,6 +3453,12 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3413,6 +3492,12 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -3428,6 +3513,12 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3449,6 +3540,12 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -3464,6 +3561,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ rustc-hash = "2"
 schemars = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+shellexpand = "3.1"
 termimad = "0.35"
 toml = "1"
 unicode-width = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ exclude = [
 default = []
 clipboard = ["arboard"]
 sound = ["rodio"]
+default-sounds = ["sound"]
 
 [dependencies]
 anyhow = "1.0"

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Run this command too if you want to update bacon. Configuration has always been 
 
 Some features are disabled by default. You may enable them with
 
-    cargo install --locked bacon --features "clipboard sound"
+    cargo install --locked bacon --features "clipboard default-sounds"
 
 Precompiled binaries are also available at https://dystroy.org/bacon/download/
 
@@ -118,6 +118,7 @@ Some bacon features can be disabled or enabled at compilation:
 
 * `"clipboard"` - disabled by default : necessary for the `copy-unstyled-output` action
 * `"sound"` - disabled by default : necessary for the `play-sound` action
+* `"default-sounds"` - disabled by default: embed some default sounds for the `play-sound` action
 
 ## Licences
 

--- a/defaults/default-prefs.toml
+++ b/defaults/default-prefs.toml
@@ -86,6 +86,13 @@ line_format = "{item-idx}: {kind} {path}:{line}:{column} {message}"
 enabled = false # set true to allow sound
 base_volume = "100%" # global volume multiplier
 
+# Specify your own sound files, e.g.
+#     bepop = "~/audio/bepop.mp3"
+#
+# Then use its name as usual in a job, e.g.
+#     on_success = "play-sound(name=bepop,volume=42)"
+[sound.collection]
+
 # Uncomment and change the key-bindings you want to define
 # (some of those ones are the defaults and are just here for illustration)
 [keybindings]

--- a/src/jobs/job.rs
+++ b/src/jobs/job.rs
@@ -318,6 +318,7 @@ fn test_job_apply() {
         sound: SoundConfig {
             enabled: Some(true),
             base_volume: Some(Volume::from_str("50").unwrap()),
+            collection: None,
         },
         workdir: Some(PathBuf::from("/path/to/workdir")),
         skin: Default::default(),

--- a/src/sound/play_sound.rs
+++ b/src/sound/play_sound.rs
@@ -19,10 +19,12 @@ struct Sound {
 
 static SOUNDS: LazyLock<RwLock<HashMap<&'static str, Sound>>> = LazyLock::new(|| {
     let mut sounds = HashMap::new();
+    #[cfg(feature = "default-sounds")]
     sounds.extend(DEFAULT_SOUNDS);
     RwLock::new(sounds)
 });
 
+#[cfg(feature = "default-sounds")]
 const DEFAULT_SOUNDS: [(&str, Sound); 15] = [
     ("2", Sound {
         bytes: include_bytes!("../../resources/2-100419.mp3"),
@@ -86,7 +88,8 @@ const DEFAULT_SOUNDS: [(&str, Sound); 15] = [
     }),
 ];
 
-/// Get a sound by name; or the default sound if name is None.
+/// Get a sound by name; or the default sound if name is None,
+/// and the default-sounds feature is enabled.
 ///
 /// There are too kinds of sounds: default and custom.
 ///
@@ -95,6 +98,10 @@ const DEFAULT_SOUNDS: [(&str, Sound); 15] = [
 /// redundancy. Resource file names are kept identical to their original
 /// names to ease retrieval for attribution).
 fn get_sound(name: Option<&str>) -> Result<Sound, SoundError> {
+    // NOTE: This doesn't distinguish from whether the default-sound feature is
+    // enabled, and might confuse users. But then again, that only happens when
+    // a default name is requested while default-sound feature is disabled,
+    // which shouldn't happen anyway.
     let name = name.unwrap_or("store-scanner");
     SOUNDS.read().unwrap().get(name).copied().ok_or_else(|| SoundError::UnknownSoundName(name.to_string()))
 }

--- a/src/sound/play_sound.rs
+++ b/src/sound/play_sound.rs
@@ -1,6 +1,6 @@
 use {
     super::*,
-    rodio::OutputStreamBuilder,
+    rodio::{OutputStreamBuilder, Decoder, Source},
     std::{
         fmt,
         collections::HashMap,
@@ -118,6 +118,8 @@ pub(crate) fn add_sound(name: &str, path: &str) -> Result<(), SoundError> {
     let bytes: &'static [u8] = std::fs::read(&path)
         .map_err(|_| SoundError::MissingSoundFile(path.to_string()))?
         .leak();
+    // TODO: check for duration right here, or use Option?
+    // If to check, might as well replace `bytes` with decoded struct
     SOUNDS.write().unwrap()
         .insert(name.to_string().leak(), Sound {
             bytes,
@@ -132,8 +134,14 @@ pub enum SoundError {
     Interrupted,
     UnknownSoundName(String),
     MissingSoundFile(String),
+    RodioDecode(rodio::decoder::DecoderError),
     RodioStream(rodio::StreamError),
     RodioPlay(rodio::PlayError),
+}
+impl From<rodio::decoder::DecoderError> for SoundError {
+    fn from(e: rodio::decoder::DecoderError) -> Self {
+        SoundError::RodioDecode(e)
+    }
 }
 impl From<rodio::StreamError> for SoundError {
     fn from(e: rodio::StreamError) -> Self {
@@ -158,6 +166,7 @@ impl fmt::Display for SoundError {
             SoundError::MissingSoundFile(path) => {
                 write!(f, "missing sound file: {}", path)
             }
+            SoundError::RodioDecode(e) => write!(f, "rodio decode error: {}", e),
             SoundError::RodioStream(e) => write!(f, "rodio stream error: {}", e),
             SoundError::RodioPlay(e) => write!(f, "rodio play error: {}", e),
         }
@@ -175,9 +184,15 @@ pub fn play_sound(
     let Sound { bytes, duration } = get_sound(psc.name.as_deref())?;
     let stream = OutputStreamBuilder::open_default_stream()?;
     let sound = Cursor::new(bytes);
+    let duration = if duration == Duration::ZERO {
+        let decoder = Decoder::new(sound.clone())?;
+        decoder.total_duration()
+    } else {
+        Some(duration)
+    };
     let sink = rodio::play(stream.mixer(), sound)?;
     sink.set_volume(psc.volume.as_part());
-    if interrupt.recv_timeout(duration).is_ok() {
+    if duration.is_some() && interrupt.recv_timeout(duration.unwrap()).is_ok() {
         info!("sound interrupted");
         Err(SoundError::Interrupted)
     } else {

--- a/src/sound/play_sound.rs
+++ b/src/sound/play_sound.rs
@@ -3,18 +3,92 @@ use {
     rodio::OutputStreamBuilder,
     std::{
         fmt,
+        collections::HashMap,
         io::Cursor,
+        sync::{LazyLock, RwLock},
         time::Duration,
     },
     termimad::crossbeam::channel::Receiver,
 };
 
+#[derive(Clone, Copy)]
 struct Sound {
     bytes: &'static [u8],
     duration: Duration,
 }
 
-/// Get a sound by name, or the default sound if name is None
+static SOUNDS: LazyLock<RwLock<HashMap<&'static str, Sound>>> = LazyLock::new(|| {
+    let mut sounds = HashMap::new();
+    sounds.extend(DEFAULT_SOUNDS);
+    RwLock::new(sounds)
+});
+
+const DEFAULT_SOUNDS: [(&str, Sound); 15] = [
+    ("2", Sound {
+        bytes: include_bytes!("../../resources/2-100419.mp3"),
+        duration: Duration::from_millis(2000),
+    }),
+    ("90s-game-ui-6", Sound {
+        bytes: include_bytes!("../../resources/90s-game-ui-6-185099.mp3"),
+        duration: Duration::from_millis(1300),
+    }),
+    ("beep-6", Sound {
+        bytes: include_bytes!("../../resources/beep-6-96243.mp3"),
+        duration: Duration::from_millis(1000),
+    }),
+    ("beep-beep", Sound {
+        bytes: include_bytes!("../../resources/beep-beep-6151.mp3"),
+        duration: Duration::from_millis(1200),
+    }),
+    ("beep-warning", Sound {
+        bytes: include_bytes!("../../resources/beep-warning-6387.mp3"),
+        duration: Duration::from_millis(1200),
+    }),
+    ("bell-chord", Sound {
+        bytes: include_bytes!("../../resources/bell-chord1-83260.mp3"),
+        duration: Duration::from_millis(1900),
+    }),
+    ("car-horn", Sound {
+        bytes: include_bytes!("../../resources/car-horn-beepsmp3-14659.mp3"),
+        duration: Duration::from_millis(1700),
+    }),
+    ("convenience-store-ring", Sound {
+        bytes: include_bytes!("../../resources/conveniencestorering-96090.mp3"),
+        duration: Duration::from_millis(1700),
+    }),
+    ("cow-bells", Sound {
+        bytes: include_bytes!("../../resources/cow_bells_01-98236.mp3"),
+        duration: Duration::from_millis(1400),
+    }),
+    ("pickup", Sound {
+        bytes: include_bytes!("../../resources/pickup-sound-46472.mp3"),
+        duration: Duration::from_millis(500),
+    }),
+    ("positive-beeps", Sound {
+        bytes: include_bytes!("../../resources/positive_beeps-85504.mp3"),
+        duration: Duration::from_millis(600),
+    }),
+    ("short-beep-tone", Sound {
+        bytes: include_bytes!("../../resources/short-beep-tone-47916.mp3"),
+        duration: Duration::from_millis(400),
+    }),
+    ("slash", Sound {
+        bytes: include_bytes!("../../resources/slash1-94367.mp3"),
+        duration: Duration::from_millis(800),
+    }),
+    ("store-scanner", Sound {
+        bytes: include_bytes!("../../resources/store-scanner-beep-90395.mp3"),
+        duration: Duration::from_millis(250),
+    }),
+    ("success", Sound {
+        bytes: include_bytes!("../../resources/success-48018.mp3"),
+        duration: Duration::from_millis(2000),
+    }),
+];
+
+/// Get a sound by name; or the default sound if name is None.
+///
+/// There are too kinds of sounds: default and custom.
 ///
 /// Names here are as near as possible from the file names in the
 /// reources directory but without the number, syntax unconsistency and
@@ -22,78 +96,35 @@ struct Sound {
 /// names to ease retrieval for attribution).
 fn get_sound(name: Option<&str>) -> Result<Sound, SoundError> {
     let name = name.unwrap_or("store-scanner");
-    let sound = match name {
-        "2" => Sound {
-            bytes: include_bytes!("../../resources/2-100419.mp3"),
-            duration: Duration::from_millis(2000),
-        },
-        "90s-game-ui-6" => Sound {
-            bytes: include_bytes!("../../resources/90s-game-ui-6-185099.mp3"),
-            duration: Duration::from_millis(1300),
-        },
-        "beep-6" => Sound {
-            bytes: include_bytes!("../../resources/beep-6-96243.mp3"),
-            duration: Duration::from_millis(1000),
-        },
-        "beep-beep" => Sound {
-            bytes: include_bytes!("../../resources/beep-beep-6151.mp3"),
-            duration: Duration::from_millis(1200),
-        },
-        "beep-warning" => Sound {
-            bytes: include_bytes!("../../resources/beep-warning-6387.mp3"),
-            duration: Duration::from_millis(1200),
-        },
-        "bell-chord" => Sound {
-            bytes: include_bytes!("../../resources/bell-chord1-83260.mp3"),
-            duration: Duration::from_millis(1900),
-        },
-        "car-horn" => Sound {
-            bytes: include_bytes!("../../resources/car-horn-beepsmp3-14659.mp3"),
-            duration: Duration::from_millis(1700),
-        },
-        "convenience-store-ring" => Sound {
-            bytes: include_bytes!("../../resources/conveniencestorering-96090.mp3"),
-            duration: Duration::from_millis(1700),
-        },
-        "cow-bells" => Sound {
-            bytes: include_bytes!("../../resources/cow_bells_01-98236.mp3"),
-            duration: Duration::from_millis(1400),
-        },
-        "pickup" => Sound {
-            bytes: include_bytes!("../../resources/pickup-sound-46472.mp3"),
-            duration: Duration::from_millis(500),
-        },
-        "positive-beeps" => Sound {
-            bytes: include_bytes!("../../resources/positive_beeps-85504.mp3"),
-            duration: Duration::from_millis(600),
-        },
-        "short-beep-tone" => Sound {
-            bytes: include_bytes!("../../resources/short-beep-tone-47916.mp3"),
-            duration: Duration::from_millis(400),
-        },
-        "slash" => Sound {
-            bytes: include_bytes!("../../resources/slash1-94367.mp3"),
-            duration: Duration::from_millis(800),
-        },
-        "store-scanner" => Sound {
-            bytes: include_bytes!("../../resources/store-scanner-beep-90395.mp3"),
-            duration: Duration::from_millis(250),
-        },
-        "success" => Sound {
-            bytes: include_bytes!("../../resources/success-48018.mp3"),
-            duration: Duration::from_millis(2000),
-        },
-        _ => {
-            return Err(SoundError::UnknownSoundName(name.to_string()));
-        }
-    };
-    Ok(sound)
+    SOUNDS.read().unwrap().get(name).copied().ok_or_else(|| SoundError::UnknownSoundName(name.to_string()))
+}
+
+/// Add a sound from a file (path).
+///
+/// Bytes are leaked, as they are loaded once and kept throughout the program's
+/// lifetime, just like the default sounds.
+/// Likewise, the name is also leaked.
+pub(crate) fn add_sound(name: &str, path: &str) -> Result<(), SoundError> {
+    // ideally we should accept AsRef<Path>, but `shellexpand::tilde` requires
+    // a AsRef<str>. To ease things, allow only allow UTF-8 paths.
+    let path = shellexpand::tilde(path).to_string();
+    let bytes: &'static [u8] = std::fs::read(&path)
+        .map_err(|_| SoundError::MissingSoundFile(path.to_string()))?
+        .leak();
+    SOUNDS.write().unwrap()
+        .insert(name.to_string().leak(), Sound {
+            bytes,
+            duration: Duration::ZERO,
+        });
+    info!("loaded sound {name:?} from {path:?}");
+    Ok(())
 }
 
 #[derive(Debug)]
 pub enum SoundError {
     Interrupted,
     UnknownSoundName(String),
+    MissingSoundFile(String),
     RodioStream(rodio::StreamError),
     RodioPlay(rodio::PlayError),
 }
@@ -116,6 +147,9 @@ impl fmt::Display for SoundError {
             SoundError::Interrupted => write!(f, "sound interrupted"),
             SoundError::UnknownSoundName(name) => {
                 write!(f, "unknown sound name: {}", name)
+            }
+            SoundError::MissingSoundFile(path) => {
+                write!(f, "missing sound file: {}", path)
             }
             SoundError::RodioStream(e) => write!(f, "rodio stream error: {}", e),
             SoundError::RodioPlay(e) => write!(f, "rodio play error: {}", e),

--- a/src/sound/play_sound.rs
+++ b/src/sound/play_sound.rs
@@ -115,17 +115,20 @@ pub(crate) fn add_sound(name: &str, path: &str) -> Result<(), SoundError> {
     // ideally we should accept AsRef<Path>, but `shellexpand::tilde` requires
     // a AsRef<str>. To ease things, allow only allow UTF-8 paths.
     let path = shellexpand::tilde(path).to_string();
-    let bytes: &'static [u8] = std::fs::read(&path)
-        .map_err(|_| SoundError::MissingSoundFile(path.to_string()))?
-        .leak();
-    // TODO: check for duration right here, or use Option?
-    // If to check, might as well replace `bytes` with decoded struct
-    SOUNDS.write().unwrap()
-        .insert(name.to_string().leak(), Sound {
-            bytes,
-            duration: Duration::ZERO,
-        });
-    info!("loaded sound {name:?} from {path:?}");
+    let bytes: Vec<u8> = std::fs::read(&path)
+        .map_err(|_| SoundError::MissingSoundFile(path.to_string()))?;
+
+    let decoder = Decoder::builder()
+        .with_data(Cursor::new(bytes.clone()))
+        .with_byte_len(bytes.len() as u64)
+        .build()?;
+    // Duration::MAX guarantees the sound is played. See discussion in
+    // https://github.com/Canop/bacon/pull/341
+    let duration = decoder.total_duration().unwrap_or(Duration::MAX);
+
+    SOUNDS.write().unwrap().insert(name.to_string().leak(), Sound { bytes: bytes.leak(), duration });
+
+    info!("loaded sound {name:?} from {path:?}, duration: {duration:?}");
     Ok(())
 }
 
@@ -184,18 +187,11 @@ pub fn play_sound(
     let Sound { bytes, duration } = get_sound(psc.name.as_deref())?;
     let stream = OutputStreamBuilder::open_default_stream()?;
     let sound = Cursor::new(bytes);
-    let duration = if duration == Duration::ZERO {
-        let decoder = Decoder::new(sound.clone())?;
-        decoder.total_duration()
-    } else {
-        Some(duration)
-    };
     let sink = rodio::play(stream.mixer(), sound)?;
     sink.set_volume(psc.volume.as_part());
-    if duration.is_some() && interrupt.recv_timeout(duration.unwrap()).is_ok() {
+    if interrupt.recv_timeout(duration).is_ok() {
         info!("sound interrupted");
-        Err(SoundError::Interrupted)
-    } else {
-        Ok(())
+        return Err(SoundError::Interrupted)
     }
+    Ok(())
 }

--- a/src/sound/sound_config.rs
+++ b/src/sound/sound_config.rs
@@ -2,6 +2,7 @@ use {
     crate::*,
     schemars::JsonSchema,
     serde::Deserialize,
+    std::collections::HashMap,
 };
 
 /// Sound configuration.
@@ -12,6 +13,7 @@ pub struct SoundConfig {
 
     /// Base volume, acting as a multiplier for the volume of specific sounds.
     pub base_volume: Option<Volume>,
+    pub collection: Option<HashMap<String, String>>,
 }
 
 impl SoundConfig {
@@ -24,6 +26,26 @@ impl SoundConfig {
         }
         if let Some(bv) = sc.base_volume {
             self.base_volume = Some(bv);
+        }
+        #[cfg(feature = "sound")]
+        // Load sounds configured in `[sound.collection]`.
+        // This doesn't "apply" this item in the sense other items are applied;
+        // but rather, add them to `super::play_sound::SOUNDS` so they can be
+        // looked up later.
+        // Ideally, they should be loaded at some more suitable point, or even
+        // passed to `super::play_sound::play_sound()` to achieve some degree
+        // of on-demand loading. But current structure of `SoundPlayer` makes
+        // that difficult.
+        if let Some(ref collection) = sc.collection {
+            let mut self_collection = self.collection.get_or_insert_default();
+            for (name, path) in collection {
+                if !self_collection.contains_key(name) {
+                    if let Err(e) = crate::sound::play_sound::add_sound(name, path) {
+                        warn!("failed to add sound(name = {name}, path = {path}): {e:?}");
+                    }
+                    self_collection.insert(name.clone(), path.clone());
+                }
+            }
         }
     }
     pub fn is_enabled(&self) -> bool {

--- a/website/src/config.md
+++ b/website/src/config.md
@@ -393,7 +393,24 @@ on_success = "play-sound(name=90s-game-ui-6,volume=50)"
 on_failure = "play-sound(name=beep-warning,volume=100)"
 ```
 
-Sound name can be omitted. Possible values are `2`, `90s-game-ui-6`, `beep-6`, `beep-beep`, `beep-warning`, `bell-chord`, `car-horn`, `convenience-store-ring`, `cow-bells`, `pickup`, `positive-beeps`, `short-beep-tone`, `slash`, `store-scanner`, `success`.
+Sound name can be omitted.
+
+If the `default-sounds` feature is enabled, some pre-chosen sounds are available; their names are `2`, `90s-game-ui-6`, `beep-6`, `beep-beep`, `beep-warning`, `bell-chord`, `car-horn`, `convenience-store-ring`, `cow-bells`, `pickup`, `positive-beeps`, `short-beep-tone`, `slash`, `store-scanner`, `success`.
+
+Or, you can add your own sounds.
+
+Add sounds to a root level collection, eg
+
+```TOML
+[sound.collection]
+bepop = "~/audio/bepop.mp3"
+```
+
+then use its name in a job as usual, eg
+
+```TOML
+on_success = "play-sound(name=bepop,volume=42)"
+```
 
 ## Skin
 
@@ -421,4 +438,3 @@ skin.status_bg = 6
 
 All available skin entries, with meaning and default values, are listed in [src/conf/skin.rs](https://github.com/Canop/bacon/blob/main/src/conf/skin.rs#62).
 Skin entries may be added or removed in minor versions of bacon. Unrecognized entries are just ignored.
-


### PR DESCRIPTION
Resolves #337.

Each commit is self contained (hopefully) and comes with explanation in its message (mostly). But to sum it up, notable changes are

- A new `[sound.collection]` config section to specify custom sounds, which can be used as `play-sound(name=custom-name)`; section name could be adjusted
- A `default-sounds` feature to allow removing, well, default sounds
- `play-sound(path=...)` for "one-off" settings