### PR TITLE
no longer override by default RUST_BACKTRACE

### DIFF
--- a/bacon.toml
+++ b/bacon.toml
@@ -91,3 +91,4 @@ ctrl-c = "copy-unstyled-output"
 #b = "play-sound(name=beep-6)"
 f = "job:fmt"
 w = "job:win"
+alt-b = "toggle-backtrace(0)" # disable backtrace when set with env var

--- a/src/exec/executor.rs
+++ b/src/exec/executor.rs
@@ -100,7 +100,9 @@ impl MissionExecutor {
             Some(Instant::now())
         };
         let mut command_builder = self.command_builder.clone();
-        command_builder.env("RUST_BACKTRACE", task.backtrace.unwrap_or("0"));
+        if let Some(backtrace) = task.backtrace {
+            command_builder.env("RUST_BACKTRACE", backtrace);
+        }
         let kill_command = self.kill_command.clone();
         let with_stdout = command_builder.is_with_stdout();
         let line_sender = self.line_sender.clone();

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -139,6 +139,7 @@ impl std::str::FromStr for Internal {
             "scope-to-failures" => Ok(Self::ScopeToFailures),
             "toggle-raw-output" => Ok(Self::ToggleRawOutput),
             "toggle-backtrace" => Ok(Self::ToggleBacktrace("1")),
+            "toggle-backtrace(0)" => Ok(Self::ToggleBacktrace("0")),
             "toggle-backtrace(1)" => Ok(Self::ToggleBacktrace("1")),
             "toggle-backtrace(2)" => Ok(Self::ToggleBacktrace("2")),
             "toggle-backtrace(full)" => Ok(Self::ToggleBacktrace("full")),


### PR DESCRIPTION
Fix #356

In order to still allow bacon to override an externally set RUST_BACKTRACE, it's now possible to define an action with toggle-backtrace(0)

Example:

```TOML
[keybindings]
alt-b = "toggle-backtrace(0)" # disable backtrace when set with env var
```