### PR TITLE
Implement changing `command`s via keyboard shortcut

### DIFF
--- a/src/exec/executor.rs
+++ b/src/exec/executor.rs
@@ -1,6 +1,7 @@
 use {
     crate::*,
     std::{
+        collections::HashSet,
         io::{
             self,
             BufRead,
@@ -75,8 +76,11 @@ impl TaskExecutor {
 
 impl MissionExecutor {
     /// Prepare the executor (no task/process/thread is started at this point)
-    pub fn new(mission: &Mission) -> anyhow::Result<Self> {
-        let command_builder = mission.get_command()?;
+    pub fn new(
+        mission: &Mission,
+        options: &HashSet<String>,
+    ) -> anyhow::Result<Self> {
+        let command_builder = mission.get_command(options)?;
         let kill_command = mission.kill_command();
         let (line_sender, line_receiver) = channel::unbounded();
         Ok(Self {

--- a/src/help/list_jobs.rs
+++ b/src/help/list_jobs.rs
@@ -24,10 +24,14 @@ pub fn print_jobs(settings: &Settings) {
     let mut jobs: Vec<_> = settings.jobs.iter().collect();
     jobs.sort_by_key(|(name, _)| name.to_string());
     for (name, job) in &jobs {
-        expander
-            .sub("jobs")
-            .set("job_name", name)
-            .set("job_command", job.command.join(" "));
+        expander.sub("jobs").set("job_name", name).set(
+            "job_command",
+            job.command
+                .iter()
+                .map(|arg| arg.to_string())
+                .collect::<Vec<_>>()
+                .join(" "),
+        );
     }
     expander.set("default_job", &settings.default_job);
     let skin = MadSkin::default();

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -37,6 +37,7 @@ pub enum Internal {
     ScopeToFailures,
     Scroll(ScrollCommand),
     ToggleBacktrace(&'static str),
+    ToggleOption(String),
     TogglePause, // either pause or unpause
     ToggleRawOutput,
     ToggleSummary,
@@ -70,6 +71,7 @@ impl Internal {
             Self::ScopeToFailures => "scope to failures".to_string(),
             Self::Scroll(scroll_command) => scroll_command.doc(),
             Self::ToggleBacktrace(level) => format!("toggle backtrace ({level})"),
+            Self::ToggleOption(option) => format!("toggle option {option:?}"),
             Self::TogglePause => "toggle pause".to_string(),
             Self::ToggleRawOutput => "toggle raw output".to_string(),
             Self::ToggleSummary => "toggle summary".to_string(),
@@ -99,6 +101,7 @@ impl fmt::Display for Internal {
             Self::ScopeToFailures => write!(f, "scope-to-failures"),
             Self::Scroll(scroll_command) => scroll_command.fmt(f),
             Self::ToggleBacktrace(level) => write!(f, "toggle-backtrace({level})"),
+            Self::ToggleOption(option) => write!(f, "toggle-option({option})"),
             Self::TogglePause => write!(f, "toggle-pause"),
             Self::ToggleRawOutput => write!(f, "toggle-raw-output"),
             Self::ToggleSummary => write!(f, "toggle-summary"),
@@ -183,6 +186,9 @@ impl std::str::FromStr for Internal {
                         file: file.trim().to_string(),
                     }));
                 }
+                if let Some((_, option)) = regex_captures!(r"^toggle-option\((.*)\)$", s) {
+                    return Ok(Self::ToggleOption(option.to_string()));
+                }
                 Err("invalid internal".to_string())
             }
         }
@@ -228,6 +234,7 @@ fn test_internal_string_round_trip() {
         Internal::Scroll(ScrollCommand::MilliPages(1561)),
         Internal::Scroll(ScrollCommand::Top),
         Internal::ToggleBacktrace("1"),
+        Internal::ToggleOption("some-op\"tion".to_string()),
         Internal::ToggleBacktrace("full"),
         Internal::TogglePause,
         Internal::ToggleSummary,

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -129,9 +129,9 @@ fn run_mission(
     let config_watcher = Watcher::new(&mission.settings.config_files, IgnorerSet::default())?;
 
     // create the executor, mission, and state
-    let mut executor = MissionExecutor::new(&mission)?;
-    let on_change_strategy = mission.job.on_change_strategy();
     let mut state = AppState::new(mission, headless)?;
+    let mut executor = MissionExecutor::new(&state.mission, &state.options)?;
+    let on_change_strategy = state.mission.job.on_change_strategy();
     if let Some(message) = message {
         state.messages.push(message);
     }
@@ -360,6 +360,19 @@ fn run_mission(
                     }
                     Internal::Scroll(scroll_command) => {
                         state.apply_scroll_command(scroll_command);
+                    }
+                    Internal::ToggleOption(option) => {
+                        if state.options.contains(&option) {
+                            state.options.remove(&option);
+                        } else {
+                            state.options.insert(option);
+                        }
+                        warn!("options: {:?}", state.options);
+                        task_executor.die();
+                        // recreate `executor` to account for the changed option
+                        executor = MissionExecutor::new(&state.mission, &state.options)?;
+                        task_executor = state.start_computation(&mut executor)?;
+                        break; // drop following actions
                     }
                     Internal::ToggleBacktrace(level) => {
                         state.toggle_backtrace(level);

--- a/src/tui/app_state.rs
+++ b/src/tui/app_state.rs
@@ -3,6 +3,7 @@ use {
     anyhow::Result,
     crokey::KeyCombination,
     std::{
+        collections::HashSet,
         io::Write,
         process::ExitStatus,
         time::Instant,
@@ -76,6 +77,7 @@ pub struct AppState<'s> {
     pub messages: Vec<Message>,
     /// the search state
     pub search: SearchState,
+    pub options: HashSet<String>,
 }
 
 impl<'s> AppState<'s> {
@@ -123,6 +125,7 @@ impl<'s> AppState<'s> {
             changes_since_last_job_start: 0,
             messages: Vec::new(),
             search: Default::default(),
+            options: HashSet::default(),
         })
     }
     pub fn focus_file(


### PR DESCRIPTION
This PR implements a feature to change job `command`s via keyboard shortcut, instead of changing `bacon.toml` or switching between different jobs.

This is done by allowing simple conditionals of the form `{ if = <option>, then = <optional-value-if-option-is-set>, else = <optional-value-if-option-is-unset> }` as elements of the `command` array for jobs.

Options start out as unset and can be toggled by the `toggle-option(...)` action. If the option is set, the `then` branch is passed to the command; else the `else` value is passed.

If the `then` or `else` clause is not given, the element is removed from the command invocation if that branch would have been taken.

Example:
```toml
default_job = "demo"

[jobs.demo]
command = [
    "echo", "Can", "be",
    { if = "first-option", then = "changed", else = "altered" },
    "based", "on", "keyboard",
    { if = "second-option", then = "shortcuts", else = "input" },
    { if = "full-sentence", then = "." },
]
need_stdout = true

[keybindings]
1 = "toggle-option(first-option)"
2 = "toggle-option(second-option)"
"." = "toggle-option(full-sentence)"
```

Initially, this starts out as printing `Can be altered based on keyboard input`, but pressing `1` or `2` toggles between `altered`/`changed` and `input`/`shortcuts` respectively. Pressing `.` adds a `.` to the end of the sentence.

For a real world application of this, see https://github.com/narpfel/panko/commit/023466def41b5d4b5e09b7704f47bf35b7f25ebc. I use `bacon run` to run the application, and sometimes I want to pass an optional command line flag, but most of the time, I don’t want that flag.

## TODO

(I wanted to get feedback if this is a feature you’re interested in before spending time on these items.)

- [ ] documentation
- [ ] changelog entry
- [ ] anything else?