### PR TITLE
Added swift build and lint support

### DIFF
--- a/src/analysis/analyzer.rs
+++ b/src/analysis/analyzer.rs
@@ -1,18 +1,7 @@
 use {
-    super::{
-        biome,
-        cargo_json,
-        cpp,
-        eslint,
-        nextest,
-        python,
-        standard,
-    },
+    super::{biome, cargo_json, cpp, eslint, nextest, python, standard, swift},
     crate::*,
-    serde::{
-        Deserialize,
-        Serialize,
-    },
+    serde::{Deserialize, Serialize},
 };
 
 /// A stateless operator building a report from a list of command output lines.
@@ -32,6 +21,8 @@ pub enum AnalyzerRef {
     PythonUnittest,
     Cpp,
     CppDoctest,
+    SwiftBuild,
+    SwiftLint,
 }
 
 impl AnalyzerRef {
@@ -47,6 +38,8 @@ impl AnalyzerRef {
             Self::CargoJson => Box::new(cargo_json::CargoJsonAnalyzer::default()),
             Self::Cpp => Box::new(cpp::CppAnalyzer::default()),
             Self::CppDoctest => Box::new(cpp::CppDoctestAnalyzer::default()),
+            Self::SwiftBuild => Box::new(swift::build::SwiftBuildAnalyzer::default()),
+            Self::SwiftLint => Box::new(swift::lint::SwiftLintAnalyzer::default()),
         }
     }
 }

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -11,12 +11,8 @@ mod nextest;
 mod python;
 mod standard;
 mod stats;
+mod swift;
 
 pub use {
-    analyzer::*,
-    item_accumulator::*,
-    line_analysis::*,
-    line_analyzer::*,
-    line_type::*,
-    stats::*,
+    analyzer::*, item_accumulator::*, line_analysis::*, line_analyzer::*, line_type::*, stats::*,
 };

--- a/src/analysis/swift/build.rs
+++ b/src/analysis/swift/build.rs
@@ -1,0 +1,121 @@
+//! Analyzer for swift build.
+//!
+//! # Config
+//!
+//! A sample bacon.toml:
+//!
+//! ```toml
+//! default_job = "swift_build"
+//!
+//! [keybindings]
+//! b = "job:swift_build"
+//!
+//! [jobs.swift_build]
+//! command = ["swift", "build"]
+//! watch = ["Sources"]
+//! need_stdout = true
+//! analyzer = "swift_build"
+//! ```
+//!
+//! # Caveats
+//!
+//! This analyzer processes warnings, but `swift build` is incremental by default, and so warnings
+//! will not be consistent. Consider treating warnings as errors if this is a problem.
+
+use crate::{Analyzer, CommandOutputLine, ItemAccumulator, Kind, LineType, TLine, TString, burp};
+
+use super::parse_swift_location;
+
+#[derive(Debug, Default)]
+pub struct SwiftBuildAnalyzer {
+    lines: Vec<CommandOutputLine>,
+}
+
+impl Analyzer for SwiftBuildAnalyzer {
+    fn start(
+        &mut self,
+        _: &crate::Mission,
+    ) {
+        self.lines.clear();
+    }
+
+    fn receive_line(
+        &mut self,
+        line: CommandOutputLine,
+        command_output: &mut crate::CommandOutput,
+    ) {
+        self.lines.push(line.clone());
+        command_output.push(line);
+    }
+
+    fn build_report(&mut self) -> anyhow::Result<crate::Report> {
+        let mut items = ItemAccumulator::default();
+
+        for line in &self.lines {
+            if let Some(diagnostic) = recognize_swift_diagnostic(&line.content) {
+                let content = match diagnostic.level {
+                    Kind::Error => burp::error_line_ts(&diagnostic.message),
+                    Kind::Warning => burp::warning_line_ts(&diagnostic.message),
+                    _ => unreachable!(),
+                };
+
+                items.start_item(diagnostic.level);
+                items.push_line(LineType::Title(diagnostic.level), content);
+                items.push_line(
+                    LineType::Location,
+                    burp::location_line(format!(
+                        "{}:{}:{}",
+                        diagnostic.path, diagnostic.line, diagnostic.column
+                    )),
+                );
+            } else {
+                items.push_line(LineType::Normal, line.content.clone());
+            }
+        }
+
+        Ok(items.report())
+    }
+}
+
+struct SwiftDiagnostic<'a> {
+    level: Kind,
+    path: &'a str,
+    line: &'a str,
+    column: &'a str,
+    message: Vec<TString>,
+}
+
+fn recognize_swift_diagnostic(line: &TLine) -> Option<SwiftDiagnostic> {
+    // Look for Swift format: path:line:column: (error|warning): message
+    let content = line.if_unstyled()?;
+
+    if let Some(error_pos) = content.find(": error: ") {
+        let location_part = &content[..error_pos];
+        let message_part = &content[error_pos + ": error: ".len()..];
+
+        if let Some((path, line_num, column)) = parse_swift_location(location_part) {
+            return Some(SwiftDiagnostic {
+                level: Kind::Error,
+                path,
+                line: line_num,
+                column,
+                message: vec![TString::new("", message_part)],
+            });
+        }
+    } else if let Some(warning_pos) = content.find(": warning: ") {
+        let location_part = &content[..warning_pos];
+        let message_part = &content[warning_pos + ": warning: ".len()..];
+
+        if let Some((path, line_num, column)) = parse_swift_location(location_part) {
+            return Some(SwiftDiagnostic {
+                level: Kind::Warning,
+                path,
+                line: line_num,
+                column,
+                message: vec![TString::new("", message_part)],
+            });
+        }
+    }
+
+    None
+}

--- a/src/analysis/swift/lint.rs
+++ b/src/analysis/swift/lint.rs
@@ -1,0 +1,139 @@
+//! Analyzer for [`swiftlint`](https://github.com/realm/SwiftLint)
+//!
+//! # Config
+//!
+//! A sample bacon.toml:
+//!
+//! ```toml
+//! [keybindings]
+//! l = "job:swift_lint"
+//!
+//! [jobs.swift_lint]
+//! wcommand = ["swiftlint", "lint", "--config", ".swiftlint.yml", "--strict"]
+//! watch = ["Sources"]
+//! need_stdout = true
+//! analyzer = "swift_lint"
+//! ```
+
+use crate::{Analyzer, CommandOutputLine, ItemAccumulator, Kind, LineType, TLine, TString, burp};
+
+use super::parse_swift_location;
+
+#[derive(Debug, Default)]
+pub struct SwiftLintAnalyzer {
+    lines: Vec<CommandOutputLine>,
+}
+
+impl Analyzer for SwiftLintAnalyzer {
+    fn start(
+        &mut self,
+        _: &crate::Mission,
+    ) {
+        self.lines.clear();
+    }
+
+    fn receive_line(
+        &mut self,
+        line: CommandOutputLine,
+        command_output: &mut crate::CommandOutput,
+    ) {
+        self.lines.push(line.clone());
+        command_output.push(line);
+    }
+
+    fn build_report(&mut self) -> anyhow::Result<crate::Report> {
+        let mut items = ItemAccumulator::default();
+
+        for line in &self.lines {
+            if let Some(diagnostic) = recognize_swiftlint_diagnostic(&line.content) {
+                let content = match diagnostic.level {
+                    Kind::Error => burp::error_line_ts(&diagnostic.message),
+                    Kind::Warning => burp::warning_line_ts(&diagnostic.message),
+                    _ => unreachable!(),
+                };
+
+                items.start_item(diagnostic.level);
+                items.push_line(LineType::Title(diagnostic.level), content);
+                items.push_line(
+                    LineType::Location,
+                    burp::location_line(format!(
+                        "{}:{}:{}",
+                        diagnostic.path, diagnostic.line, diagnostic.column
+                    )),
+                );
+
+                if let Some(rule) = diagnostic.rule {
+                    items.push_line(LineType::Normal, TLine::from_raw(format!("Rule: {}", rule)));
+                }
+            } else {
+                items.push_line(LineType::Normal, line.content.clone());
+            }
+        }
+
+        Ok(items.report())
+    }
+}
+
+struct SwiftLintDiagnostic<'a> {
+    level: Kind,
+    path: &'a str,
+    line: &'a str,
+    column: &'a str,
+    message: Vec<TString>,
+    rule: Option<&'a str>,
+}
+
+fn recognize_swiftlint_diagnostic(line: &TLine) -> Option<SwiftLintDiagnostic> {
+    let content = line.if_unstyled()?;
+
+    // Skip linting progress lines
+    if content.starts_with("Linting '") || content.starts_with("Done linting!") {
+        return None;
+    }
+
+    if let Some(error_pos) = content.find(": error: ") {
+        let location_part = &content[..error_pos];
+        let message_part = &content[error_pos + ": error: ".len()..];
+
+        if let Some((path, line_num, column)) = parse_swift_location(location_part) {
+            let (message, rule) = extract_message_and_rule(message_part);
+            return Some(SwiftLintDiagnostic {
+                level: Kind::Error,
+                path,
+                line: line_num,
+                column,
+                message: vec![TString::new("", message)],
+                rule,
+            });
+        }
+    } else if let Some(warning_pos) = content.find(": warning: ") {
+        let location_part = &content[..warning_pos];
+        let message_part = &content[warning_pos + ": warning: ".len()..];
+
+        if let Some((path, line_num, column)) = parse_swift_location(location_part) {
+            let (message, rule) = extract_message_and_rule(message_part);
+            return Some(SwiftLintDiagnostic {
+                level: Kind::Warning,
+                path,
+                line: line_num,
+                column,
+                message: vec![TString::new("", message)],
+                rule,
+            });
+        }
+    }
+
+    None
+}
+
+fn extract_message_and_rule(message_part: &str) -> (&str, Option<&str>) {
+    // Look for rule name in parentheses at the end: "message (rule_name)"
+    if let Some(last_paren) = message_part.rfind('(') {
+        if message_part.ends_with(')') {
+            let message = message_part[..last_paren].trim();
+            let rule = &message_part[last_paren + 1..message_part.len() - 1];
+            return (message, Some(rule));
+        }
+    }
+    (message_part, None)
+}

--- a/src/analysis/swift/mod.rs
+++ b/src/analysis/swift/mod.rs
@@ -1,0 +1,15 @@
+pub mod build;
+pub mod lint;
+
+fn parse_swift_location(location_str: &str) -> Option<(&str, &str, &str)> {
+    // splitting from the right to avoid colons in path
+    let parts: Vec<&str> = location_str.rsplitn(3, ':').collect();
+    if parts.len() == 3 {
+        let path = parts[2];
+        let line = parts[1];
+        let column = parts[0];
+        Some((path, line, column)) // path, line, column
+    } else {
+        None
+    }
+}


### PR DESCRIPTION
This PR introduces bacon support for swift build and SwiftLint. It was tested on my Mac with the following config:

```toml
default_job = "swift_build"

[keybindings]
b = "job:swift_build"
l = "job:swift_lint"

[jobs.swift_build]
command = ["swift", "build"]
watch = ["Sources"]
need_stdout = true
analyzer = "swift_build"

[jobs.swift_lint]
command = ["swiftlint", "lint", "--config", ".swiftlint.yml", "--strict"]
watch = ["Sources"]
need_stdout = true
analyzer = "swift_lint"
```
Here were the results:

## Linting Failure
<img width="1131" alt="Screenshot 2025-05-29 at 08 28 38" src="https://github.com/user-attachments/assets/1396f3c1-f1c6-445a-8db6-705a6a77bdc7" />

## Linting pass
<img width="1093" alt="Screenshot 2025-05-29 at 08 30 10" src="https://github.com/user-attachments/assets/c76e1853-185f-4faa-9424-6e17e2015ff6" />

## Build failure
<img width="1137" alt="Screenshot 2025-05-29 at 08 30 47" src="https://github.com/user-attachments/assets/74f97690-43c5-46c5-9abd-47b185beb963" />

## Build pass
<img width="606" alt="Screenshot 2025-05-29 at 08 31 10" src="https://github.com/user-attachments/assets/7e348585-474b-410e-bc4d-cce501c97c21" />

I also noticed as I developed that my formatter reformatted a few import statements. Since that was automatic, it didn't bother me, but let me know if it bothers you and I can conform it to whatever standard you have.

In my swift Package I don't currently have unit tests, but I'm open to adding that if anyone requests it.