### PR TITLE
workdir optional setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### next
 - the concept of "internals" has been removed. They were a category of actions and they're just actions now. This has no functional impact.
+- the optional `workdir` job setting allows explicitely overriding the execution directory of a job's command - experimental, feedback welcome
 
 <a name="v3.14.0"></a>
 ### v3.14.0 - 2025/05/19

--- a/src/context.rs
+++ b/src/context.rs
@@ -193,7 +193,17 @@ impl Context {
             }
         }
 
-        let execution_directory = self.package_directory.clone();
+        let mut conf_execution_directory = job.workdir.as_ref();
+        if let Some(path) = conf_execution_directory {
+            if !path.exists() {
+                error!("Ignoring configured non existing workdir: {:?}", path);
+                conf_execution_directory = None;
+            }
+        }
+        let execution_directory = conf_execution_directory
+            .unwrap_or(&self.package_directory)
+            .to_path_buf();
+
         Ok(Mission {
             location_name,
             concrete_job_ref,

--- a/src/jobs/job.rs
+++ b/src/jobs/job.rs
@@ -1,11 +1,13 @@
 use {
     crate::*,
     serde::Deserialize,
-    std::collections::HashMap,
+    std::{
+        collections::HashMap,
+        path::PathBuf,
+    },
 };
 
 /// One of the possible jobs that bacon can run
-/// One of the possible job that bacon can run
 #[derive(Debug, Default, Clone, Deserialize, PartialEq)]
 pub struct Job {
     /// Whether to consider that we can have a success
@@ -103,6 +105,10 @@ pub struct Job {
 
     #[serde(default)]
     pub sound: SoundConfig,
+
+    /// An optional working directory for the job command, which
+    /// would override the package directory.
+    pub workdir: Option<PathBuf>,
 }
 
 static DEFAULT_ARGS: &[&str] = &["--color", "always"];
@@ -227,6 +233,9 @@ impl Job {
             self.show_changes_count = Some(b);
         }
         self.sound.apply(&job.sound);
+        if let Some(p) = job.workdir.as_ref() {
+            self.workdir = Some(p.clone());
+        }
     }
 }
 
@@ -261,6 +270,7 @@ fn test_job_apply() {
             enabled: Some(true),
             base_volume: Some(Volume::from_str("50").unwrap()),
         },
+        workdir: Some(PathBuf::from("/path/to/workdir")),
     };
     base_job.apply(&job_to_apply);
     dbg!(&base_job);

--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -92,6 +92,7 @@ need_stdout |whether we need to capture stdout too (stderr is always captured) |
 on_change_strategy | `wait_then_restart` or `kill_then_restart` |
 on_success | the action to run when there's no error, warning or test failures |
 watch | a list of files and directories that will be watched if the job is run on a package. Usual source directories are implicitly included unless `default_watch` is set to false |
+workdir | overrides the execution directory |
 
 All these properties can also be defined before jobs and will apply to all of them unless overriden.
 


### PR DESCRIPTION
With this new optional setting, the execution directory of a job can be explicitly defined instead of being the package directory.


Example:

```
[jobs.wd]
command = [
	"/usr/bin/pwd"
]
need_stdout = true
workdir = "doc"
```

The provided path, if not absolute, will be considered relative to the workdir of bacon.
