### PR TITLE
Bacon colors configuration (skin)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### next
+- bacon colors configuration, see https://dystroy.org/bacon/config/#skin - Fix #215
+
 <a name="v3.11.0"></a>
 ### v3.11.0 - 2025/06/01
 - the concept of "internals" has been removed. They were a category of actions and they're just actions now. This has no functional impact.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,6 +181,7 @@ dependencies = [
  "iq",
  "lazy-regex",
  "notify",
+ "paste",
  "rodio",
  "rustc-hash 2.1.1",
  "serde",
@@ -2336,6 +2337,12 @@ dependencies = [
  "smallvec",
  "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "percent-encoding"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,6 +182,7 @@ dependencies = [
  "lazy-regex",
  "notify",
  "paste",
+ "pretty_assertions",
  "rodio",
  "rustc-hash 2.1.1",
  "serde",
@@ -707,6 +708,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
@@ -2381,6 +2388,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3539,6 +3556,12 @@ dependencies = [
  "nix 0.29.0",
  "thiserror 1.0.69",
 ]
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ iq = { version = "0.4", features = ["template"] }
 lazy-regex = "3.4.1"
 notify = "7.0"
 paste = "1.0"
+pretty_assertions = "1.4"
 rodio = { version = "0.20", optional = true, default-features = false, features = ["mp3"] }
 rustc-hash = "2"
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ glob = "0.3"
 iq = { version = "0.4", features = ["template"] }
 lazy-regex = "3.4.1"
 notify = "7.0"
+paste = "1.0"
 rodio = { version = "0.20", optional = true, default-features = false, features = ["mp3"] }
 rustc-hash = "2"
 serde = { version = "1.0", features = ["derive"] }

--- a/bacon.toml
+++ b/bacon.toml
@@ -79,6 +79,7 @@ command = [
 	"-A", "clippy::len_without_is_empty",
 	"-A", "clippy::map_entry",
 	"-A", "clippy::while_let_on_iterator",
+	"-A", "clippy::new_without_default",
 ]
 need_stdout = false
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -205,7 +205,7 @@ impl Args {
         let skin = printer.skin_mut();
         skin.headers[0].compound_style.set_fg(ansi(204));
         skin.bold.set_fg(ansi(204));
-        skin.italic = termimad::CompoundStyle::with_fg(ansi(204)); // 2, 81, 73, 38
+        skin.italic = termimad::CompoundStyle::with_fg(ansi(204));
         printer.template_keys_mut().push("examples");
         printer.set_template("examples", EXAMPLES_TEMPLATE);
         for (i, example) in EXAMPLES.iter().enumerate() {

--- a/src/conf/mod.rs
+++ b/src/conf/mod.rs
@@ -4,8 +4,8 @@ mod cargo_wrapped_config;
 mod config;
 mod defaults;
 mod keybindings;
-
 mod settings;
+mod skin;
 
 pub use {
     action::*,
@@ -15,6 +15,7 @@ pub use {
     defaults::*,
     keybindings::*,
     settings::*,
+    skin::*,
 };
 
 use std::path::{

--- a/src/conf/skin.rs
+++ b/src/conf/skin.rs
@@ -1,14 +1,14 @@
 use {
-    serde::Deserialize,
     paste::paste,
+    serde::Deserialize,
     termimad::{
-        crossterm::{
-            style::{
-                Color,
-                Attribute,
-                Color::*,
-                Print,
+        crossterm::style::{
+            Attribute,
+            Color::{
+                self,
+                *,
             },
+            Print,
         },
         minimad::{
             Alignment,

--- a/src/conf/skin.rs
+++ b/src/conf/skin.rs
@@ -87,6 +87,12 @@ BaconSkin! {
     found_selected_bg: 208, // background color of a selected search match
     search_input_prefix_fg: 208, // foreground color of the '/' search prefix
     search_summary_fg: 208, // foreground color of the search summary
+    menu_border: 234,
+    menu_bg: 235,
+    menu_item_bg: 235,
+    menu_item_selected_bg: 239,
+    menu_item_fg: 250,
+    menu_item_selected_fg: 255,
 }
 
 #[test]

--- a/src/conf/skin.rs
+++ b/src/conf/skin.rs
@@ -1,20 +1,7 @@
 use {
     paste::paste,
     serde::Deserialize,
-    termimad::{
-        crossterm::style::{
-            Attribute,
-            Color::{
-                self,
-                *,
-            },
-            Print,
-        },
-        minimad::{
-            Alignment,
-            Composite,
-        },
-    },
+    termimad::crossterm::style::Color,
 };
 
 /// Define a BaconSkin struct with fields being u8 with default values.

--- a/src/conf/skin.rs
+++ b/src/conf/skin.rs
@@ -1,0 +1,127 @@
+use {
+    serde::Deserialize,
+    paste::paste,
+    termimad::{
+        crossterm::{
+            style::{
+                Color,
+                Attribute,
+                Color::*,
+                Print,
+            },
+        },
+        minimad::{
+            Alignment,
+            Composite,
+        },
+    },
+};
+
+/// Define a BaconSkin struct with fields being u8 with default values.
+macro_rules! BaconSkin {
+    (
+        $( $name:ident: $default:literal, )*
+    ) => {
+        paste! {
+            $(
+                #[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq)]
+                #[serde(untagged)]
+                pub enum [<Defaulting$name:camel>] {
+                    Set(u8),
+                    #[default]
+                    Unset,
+                }
+                impl [<Defaulting$name:camel>] {
+                    pub fn value(self) -> u8 {
+                        match self {
+                            Self::Set(value) => value,
+                            Self::Unset => $default,
+                        }
+                    }
+                    pub fn apply(&mut self, other: Self) {
+                        if let Self::Set(value) = other {
+                            *self = Self::Set(value);
+                        }
+                    }
+                    pub fn color(self) -> Color {
+                        Color::AnsiValue(self.value())
+                    }
+                }
+            )*
+            #[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq)]
+            pub struct BaconSkin {
+                $(
+                    #[serde(default)]
+                    pub $name: [<Defaulting$name:camel>],
+                )*
+            }
+            impl BaconSkin {
+                pub fn apply(&mut self, other: Self) {
+                    $(
+                        self.$name.apply(other.$name);
+                    )*
+                }
+                $(
+                    #[inline]
+                    pub fn [<$name>](&self) -> u8 {
+                        self.$name.value()
+                    }
+                )*
+            }
+        }
+    }
+}
+
+// The colors of Bacon, with default values (ANSI color codes, in 0-255)
+BaconSkin! {
+    status_fg: 252, // foreground color of the status line
+    status_bg: 239, // background color of the status line
+    key_fg: 204, // generally used for key shortcuts
+    status_key_fg: 204, // key shortcuts when displayed in the status line
+    project_name_badge_fg: 255, // foreground color of the project name badge
+    project_name_badge_bg: 240, // background color of the project name badge
+    job_label_badge_fg: 235, // foreground color of the job label badge
+    job_label_badge_bg: 204, // background color of the job label badge
+    errors_badge_fg: 235, // foreground color of the errors badge
+    errors_badge_bg: 9, // background color of the errors badge
+    test_fails_badge_fg: 235, // foreground color of the test fails badge
+    test_fails_badge_bg: 208, // background color of the test fails badge
+    test_pass_badge_fg: 254, // foreground color of the pass! badge
+    test_pass_badge_bg: 2, // background color of the pass! badge
+    warnings_badge_fg: 235, // foreground color of the warnings badge
+    warnings_badge_bg: 11, // background color of the warnings badge
+    command_error_badge_fg: 235, // foreground color of the command error badge
+    command_error_badge_bg: 9, // background color of the command error badge
+    change_badge_fg: 235, // foreground color of the change badge
+    change_badge_bg: 6, // background color of the change badge
+    computing_fg: 235, // foreground color of the "computing..." stripe
+    computing_bg: 204, // background color of the "computing..." stripe
+    found_fg: 208, // foreground color of search matches
+    found_selected_bg: 208, // background color of a selected search match
+    search_input_prefix_fg: 208, // foreground color of the '/' search prefix
+    search_summary_fg: 208, // foreground color of the search summary
+}
+
+#[test]
+fn test_bacon_skin_defaults() {
+    let a = r"
+        status_fg = 255
+        status_key_fg = 200
+        project_name_badge_fg = 0
+    ";
+    let mut a = toml::from_str::<BaconSkin>(a).unwrap();
+    assert_eq!(a.status_fg(), 255);
+    assert_eq!(a.status_bg(), 239);
+    let b = r"
+        status_key_fg = 206
+        status_bg = 100
+    ";
+    let b = toml::from_str::<BaconSkin>(b).unwrap();
+    a.apply(b);
+    assert_eq!(a.status_fg(), 255);
+    assert_eq!(a.status_bg(), 100);
+    assert_eq!(a.key_fg(), 204);
+    assert_eq!(a.status_key_fg(), 206);
+    assert_eq!(a.project_name_badge_fg(), 0);
+    assert_eq!(a.project_name_badge_bg(), 240);
+}

--- a/src/help/help_line.rs
+++ b/src/help/help_line.rs
@@ -22,53 +22,53 @@ impl HelpLine {
     pub fn new(settings: &Settings) -> Self {
         let kb = &settings.keybindings;
         let quit = kb
-            .shortest_internal_key(Action::Quit)
+            .shortest_key_for(&Action::Quit)
             .map(|k| format!("*{k}* to quit"))
             .expect("the app to be quittable");
         let toggle_summary = kb
-            .shortest_internal_key(Action::ToggleSummary)
+            .shortest_key_for(&Action::ToggleSummary)
             .map(|k| format!("*{k}* to toggle summary mode"));
         let wrap = kb
-            .shortest_internal_key(Action::ToggleWrap)
+            .shortest_key_for(&Action::ToggleWrap)
             .map(|k| format!("*{k}* to wrap lines"));
         let not_wrap = kb
-            .shortest_internal_key(Action::ToggleWrap)
+            .shortest_key_for(&Action::ToggleWrap)
             .map(|k| format!("*{k}* to not wrap lines"));
         let toggle_backtrace = kb
-            .shortest_action_key(|action| matches!(action, Action::ToggleBacktrace(_)))
+            .shortest_key(|action| matches!(action, Action::ToggleBacktrace(_)))
             .map(|k| format!("*{k}* to toggle backtraces"));
         let help = kb
-            .shortest_internal_key(Action::Help)
+            .shortest_key_for(&Action::Help)
             .map(|k| format!("*{k}* for help"));
         let close_help = kb
-            .shortest_internal_key(Action::Back)
-            .or_else(|| kb.shortest_internal_key(Action::Help))
+            .shortest_key_for(&Action::Back)
+            .or_else(|| kb.shortest_key_for(&Action::Help))
             .map(|k| format!("*{k}* to close this help"));
         let pause = kb
-            .shortest_internal_key(Action::Pause)
-            .or(kb.shortest_internal_key(Action::TogglePause))
+            .shortest_key_for(&Action::Pause)
+            .or(kb.shortest_key_for(&Action::TogglePause))
             .map(|k| format!("*{k}* to pause"));
         let unpause = kb
-            .shortest_internal_key(Action::Unpause)
-            .or(kb.shortest_internal_key(Action::TogglePause))
+            .shortest_key_for(&Action::Unpause)
+            .or(kb.shortest_key_for(&Action::TogglePause))
             .map(|k| format!("*{k}* to unpause"));
         let scope = kb
-            .shortest_internal_key(Action::ScopeToFailures)
+            .shortest_key_for(&Action::ScopeToFailures)
             .map(|k| format!("*{k}* to scope to failures"));
         let search = kb
-            .shortest_internal_key(Action::FocusSearch)
+            .shortest_key_for(&Action::FocusSearch)
             .map(|k| format!("*{k}* to search"));
         let next_match = kb
-            .shortest_internal_key(Action::NextMatch)
+            .shortest_key_for(&Action::NextMatch)
             .map(|k| format!("*{k}* for next match"));
         let previous_match = kb
-            .shortest_internal_key(Action::PreviousMatch)
+            .shortest_key_for(&Action::PreviousMatch)
             .map(|k| format!("*{k}* for previous match"));
         let clear_search = kb
-            .shortest_internal_key(Action::Back)
+            .shortest_key_for(&Action::Back)
             .map(|k| format!("*{k}* to clear"));
         let validate_search = kb
-            .shortest_internal_key(Action::Validate)
+            .shortest_key_for(&Action::Validate)
             .map(|k| format!("*{k}* to validate"));
         Self {
             quit,

--- a/src/help/help_page.rs
+++ b/src/help/help_page.rs
@@ -56,9 +56,10 @@ impl HelpPage {
     pub fn new(settings: &Settings) -> Self {
         let mut skin = MadSkin::default();
         skin.paragraph.align = Alignment::Center;
-        skin.italic = CompoundStyle::new(Some(AnsiValue(204)), None, Attribute::Bold.into());
+        let key_color = settings.all_jobs.skin.key_fg.color();
+        skin.italic = CompoundStyle::new(Some(key_color), None, Attribute::Bold.into());
         skin.table.align = Alignment::Center;
-        skin.bullet.set_fg(AnsiValue(204));
+        skin.bullet.set_fg(key_color);
         let mut expander = OwningTemplateExpander::new();
         expander.set("version", env!("CARGO_PKG_VERSION"));
         let mut bindings: Vec<(String, String)> = settings

--- a/src/help/help_page.rs
+++ b/src/help/help_page.rs
@@ -7,10 +7,7 @@ use {
         FmtText,
         MadSkin,
         TextView,
-        crossterm::style::{
-            Attribute,
-            Color::*,
-        },
+        crossterm::style::Attribute,
         minimad::{
             Alignment,
             OwningTemplateExpander,

--- a/src/jobs/job.rs
+++ b/src/jobs/job.rs
@@ -109,6 +109,9 @@ pub struct Job {
     /// An optional working directory for the job command, which
     /// would override the package directory.
     pub workdir: Option<PathBuf>,
+
+    #[serde(default)]
+    pub skin: BaconSkin,
 }
 
 static DEFAULT_ARGS: &[&str] = &["--color", "always"];
@@ -236,6 +239,7 @@ impl Job {
         if let Some(p) = job.workdir.as_ref() {
             self.workdir = Some(p.clone());
         }
+        self.skin.apply(job.skin);
     }
 }
 
@@ -271,6 +275,7 @@ fn test_job_apply() {
             base_volume: Some(Volume::from_str("50").unwrap()),
         },
         workdir: Some(PathBuf::from("/path/to/workdir")),
+        skin: Default::default(),
     };
     base_job.apply(&job_to_apply);
     dbg!(&base_job);

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -27,9 +27,6 @@ pub struct Found {
     pub continued: Option<TRange>,
 }
 
-pub const CSI_FOUND: &str = "\u{1b}[1m\u{1b}[38;5;208m"; // bold, orange foreground
-pub const CSI_FOUND_SELECTED: &str = "\u{1b}[1m\u{1b}[30m\u{1b}[48;5;208m"; // bold, orange background
-
 pub enum Search {
     Pattern(Pattern),
     ItemIdx(usize),

--- a/src/tty/mod.rs
+++ b/src/tty/mod.rs
@@ -59,3 +59,9 @@ pub fn draw(
     }
     Ok(())
 }
+pub fn csi(
+    fg: u8,
+    bg: u8,
+) -> String {
+    format!("\u{1b}[1m\u{1b}[38;5;{}m\u{1b}[48;5;{}m", fg, bg)
+}

--- a/src/tty/tstring.rs
+++ b/src/tty/tstring.rs
@@ -46,7 +46,7 @@ impl TString {
         bg: u8,
     ) -> Self {
         Self {
-            csi: format!("\u{1b}[1m\u{1b}[38;5;{}m\u{1b}[48;5;{}m", fg, bg),
+            csi: csi(fg, bg),
             raw: format!(" {} ", con),
         }
     }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -244,10 +244,15 @@ fn run_mission(
                     Event::Key(key_event) => {
                         let key_combination = KeyCombination::from(key_event);
                         debug!("key combination pressed: {}", key_combination);
-                        if !state.apply_key_combination(key_combination) {
-                            let action = keybindings.get(key_combination);
-                            if let Some(action) = action {
-                                actions.push(action.clone());
+                        match state.on_key(key_combination) {
+                            Some(action) => {
+                                actions.push(action);
+                            }
+                            None => {
+                                let action = keybindings.get(key_combination);
+                                if let Some(action) = action {
+                                    actions.push(action.clone());
+                                }
                             }
                         }
                     }
@@ -322,6 +327,12 @@ fn run_mission(
                     state.next_match();
                 }
                 Action::NoOp => {}
+                Action::OpenJobsMenu => {
+                    state.open_jobs_menu();
+                }
+                Action::OpenMenu(definition) => {
+                    state.open_menu(*definition);
+                }
                 Action::Pause => {
                     state.auto_refresh = AutoRefresh::Paused;
                 }

--- a/src/tui/app_state.rs
+++ b/src/tui/app_state.rs
@@ -16,7 +16,10 @@ use {
             execute,
             style::{
                 Attribute,
-                Color::*,
+                Color::{
+                    self,
+                    *,
+                },
                 Print,
             },
         },
@@ -85,10 +88,15 @@ impl<'s> AppState<'s> {
     ) -> Result<Self> {
         let report_maker = ReportMaker::new(&mission);
         let mut status_skin = MadSkin::default();
+        let skin = mission.job.skin;
         status_skin
             .paragraph
-            .set_fgbg(AnsiValue(252), AnsiValue(239));
-        status_skin.italic = CompoundStyle::new(Some(AnsiValue(204)), None, Attribute::Bold.into());
+            .set_fgbg(skin.status_fg.color(), skin.status_bg.color());
+        status_skin.italic = CompoundStyle::new(
+            Some(skin.status_key_fg.color()),
+            None,
+            Attribute::Bold.into(),
+        );
         let (width, height) = if headless {
             (50, 50)
         } else {
@@ -559,7 +567,9 @@ impl<'s> AppState<'s> {
         // Search input
         if self.search.must_be_drawn() {
             let search_width = (self.width / 4).clamp(9, 27);
-            self.search.draw_prefixed_input(w, 0, y, search_width)?;
+            let skin = self.mission.job.skin;
+            let csi = format!("\u{1b}[1m\u{1b}[38;5;{}m", skin.search_input_prefix_fg());
+            self.search.draw_prefixed_input(w, 0, y, &csi, search_width)?;
             help_start += search_width;
         }
         goto(w, help_start, y)?;
@@ -584,27 +594,46 @@ impl<'s> AppState<'s> {
     pub fn job_badges(&self) -> Vec<TString> {
         let mut badges = Vec::new();
         let project_name = &self.mission.location_name;
-        badges.push(TString::badge(project_name, 255, 240));
+        let skin = self.mission.job.skin;
+        badges.push(TString::badge(
+            project_name,
+            skin.project_name_badge_fg(),
+            skin.project_name_badge_bg(),
+        ));
         let job_label = self.mission.concrete_job_ref.badge_label();
-        badges.push(TString::badge(&job_label, 235, 204));
+        badges.push(TString::badge(
+            &job_label,
+            skin.job_label_badge_fg(),
+            skin.job_label_badge_bg(),
+        ));
         if let CommandResult::Report(report) = &self.cmd_result {
             let stats = &report.stats;
             if stats.errors > 0 {
-                badges.push(TString::num_badge(stats.errors, "error", 235, 9));
+                badges.push(TString::num_badge(
+                    stats.errors,
+                    "error",
+                    skin.errors_badge_fg(),
+                    skin.errors_badge_bg(),
+                ));
             }
             if stats.test_fails > 0 {
-                badges.push(TString::num_badge(stats.test_fails, "fail", 235, 208));
+                badges.push(TString::num_badge(
+                    stats.test_fails,
+                    "fail",
+                    skin.test_fails_badge_fg(),
+                    skin.test_fails_badge_bg(),
+                ));
             } else if stats.passed_tests > 0 {
-                badges.push(TString::badge("pass!", 254, 2));
+                badges.push(TString::badge("pass!", skin.test_pass_badge_fg(), skin.test_pass_badge_bg()));
             }
             if stats.warnings > 0 {
-                badges.push(TString::num_badge(stats.warnings, "warning", 235, 11));
+                badges.push(TString::num_badge(stats.warnings, "warning", skin.warnings_badge_fg(), skin.warnings_badge_bg()));
             }
         } else if let CommandResult::Failure(failure) = &self.cmd_result {
             badges.push(TString::badge(
                 &format!("Command error code: {}", failure.error_code),
-                235,
-                9,
+                skin.command_error_badge_fg(),
+                skin.command_error_badge_bg(),
             ));
         }
         badges
@@ -616,6 +645,7 @@ impl<'s> AppState<'s> {
         w: &mut W,
         y: u16,
     ) -> Result<usize> {
+        let skin = self.mission.job.skin;
         goto_line(w, y)?;
         let mut t_line = TLine::default();
         for badge in self.job_badges() {
@@ -625,11 +655,14 @@ impl<'s> AppState<'s> {
             t_line.add_badge(TString::num_badge(
                 self.changes_since_last_job_start,
                 "change",
-                235,
-                6,
+                skin.change_badge_fg(),
+                skin.change_badge_bg(),
             ));
         }
-        self.search.add_summary_tstring(&mut t_line);
+        if self.search.input_has_content() {
+            let csi_found = format!("\u{1b}[1m\u{1b}[38;5;{}m", skin.found_fg()); // bold, colored foreground
+            self.search.add_summary_tstring(&mut t_line, &csi_found);
+        }
         let width = self.width as usize;
         let cols = t_line.draw_in(w, width)?;
         clear_line(w)?;
@@ -642,11 +675,14 @@ impl<'s> AppState<'s> {
         y: u16,
     ) -> Result<()> {
         goto_line(w, y)?;
+        let skin = self.mission.job.skin;
         let width = self.width as usize;
         if self.computing {
             write!(
                 w,
-                "\u{1b}[38;5;235m\u{1b}[48;5;204m{:^w$}\u{1b}[0m",
+                "\u{1b}[38;5;{}m\u{1b}[48;5;{}m{:^w$}\u{1b}[0m",
+                skin.computing_fg(),
+                skin.computing_bg(),
                 "computing...",
                 w = width
             )?;
@@ -768,6 +804,9 @@ impl<'s> AppState<'s> {
         if self.height < 4 {
             return Ok(());
         }
+        let skin = self.mission.job.skin;
+        let csi_found = format!("\u{1b}[1m\u{1b}[38;5;{}m", skin.found_fg()); // bold, colored foreground
+        let csi_found_selected = format!("\u{1b}[1m\u{1b}[30m\u{1b}[48;5;{}m", skin.found_selected_bg()); // bold, colored background
         let area = Area::new(0, y, self.width - 1, self.page_height() as u16);
         let content_height = self.content_height();
         let scrollbar = area.scrollbar(self.scroll, content_height);
@@ -787,9 +826,9 @@ impl<'s> AppState<'s> {
         let mut lines = lines.enumerate().skip(self.scroll);
         let mut found_idx = 0;
         #[derive(Debug)]
-        struct PendingContinuation {
+        struct PendingContinuation<'s> {
             trange: TRange,
-            style: &'static str,
+            style: &'s str,
         }
         let mut pending_continuation = None;
         for row_idx in 0..area.height {
@@ -828,9 +867,9 @@ impl<'s> AppState<'s> {
                         for (in_line_idx, found) in line_founds.iter().enumerate().rev() {
                             let cur_idx = found_idx_before_line + in_line_idx;
                             let style = if self.search.selected_found() == cur_idx {
-                                CSI_FOUND_SELECTED
+                                &csi_found_selected
                             } else {
-                                CSI_FOUND
+                                &csi_found
                             };
                             modified.change_range_style(found.trange, style.to_string());
                             if let Some(continued) = &found.continued {

--- a/src/tui/app_state.rs
+++ b/src/tui/app_state.rs
@@ -569,7 +569,8 @@ impl<'s> AppState<'s> {
             let search_width = (self.width / 4).clamp(9, 27);
             let skin = self.mission.job.skin;
             let csi = format!("\u{1b}[1m\u{1b}[38;5;{}m", skin.search_input_prefix_fg());
-            self.search.draw_prefixed_input(w, 0, y, &csi, search_width)?;
+            self.search
+                .draw_prefixed_input(w, 0, y, &csi, search_width)?;
             help_start += search_width;
         }
         goto(w, help_start, y)?;
@@ -624,10 +625,19 @@ impl<'s> AppState<'s> {
                     skin.test_fails_badge_bg(),
                 ));
             } else if stats.passed_tests > 0 {
-                badges.push(TString::badge("pass!", skin.test_pass_badge_fg(), skin.test_pass_badge_bg()));
+                badges.push(TString::badge(
+                    "pass!",
+                    skin.test_pass_badge_fg(),
+                    skin.test_pass_badge_bg(),
+                ));
             }
             if stats.warnings > 0 {
-                badges.push(TString::num_badge(stats.warnings, "warning", skin.warnings_badge_fg(), skin.warnings_badge_bg()));
+                badges.push(TString::num_badge(
+                    stats.warnings,
+                    "warning",
+                    skin.warnings_badge_fg(),
+                    skin.warnings_badge_bg(),
+                ));
             }
         } else if let CommandResult::Failure(failure) = &self.cmd_result {
             badges.push(TString::badge(
@@ -806,7 +816,10 @@ impl<'s> AppState<'s> {
         }
         let skin = self.mission.job.skin;
         let csi_found = format!("\u{1b}[1m\u{1b}[38;5;{}m", skin.found_fg()); // bold, colored foreground
-        let csi_found_selected = format!("\u{1b}[1m\u{1b}[30m\u{1b}[48;5;{}m", skin.found_selected_bg()); // bold, colored background
+        let csi_found_selected = format!(
+            "\u{1b}[1m\u{1b}[30m\u{1b}[48;5;{}m",
+            skin.found_selected_bg()
+        ); // bold, colored background
         let area = Area::new(0, y, self.width - 1, self.page_height() as u16);
         let content_height = self.content_height();
         let scrollbar = area.scrollbar(self.scroll, content_height);

--- a/src/tui/app_state.rs
+++ b/src/tui/app_state.rs
@@ -16,10 +16,6 @@ use {
             execute,
             style::{
                 Attribute,
-                Color::{
-                    self,
-                    *,
-                },
                 Print,
             },
         },

--- a/src/tui/dialog.rs
+++ b/src/tui/dialog.rs
@@ -1,0 +1,17 @@
+use super::*;
+
+/// the dialog that may be displayed over the rest of the UI
+#[allow(clippy::large_enum_variant)]
+pub enum Dialog {
+    None,
+    Menu(ActionMenu),
+}
+
+impl Dialog {
+    pub fn is_none(&self) -> bool {
+        matches!(self, Self::None)
+    }
+    pub fn is_some(&self) -> bool {
+        !self.is_none()
+    }
+}

--- a/src/tui/menu/action_menu.rs
+++ b/src/tui/menu/action_menu.rs
@@ -1,0 +1,45 @@
+use crate::*;
+
+pub type ActionMenu = Menu<Action>;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ActionMenuDefinition {
+    pub intro: Option<String>,
+    pub actions: Vec<Action>,
+}
+
+impl ActionMenu {
+    pub fn add_action(
+        &mut self,
+        action: Action,
+    ) {
+        self.add_item(action, None); // TODO look for key combination in settings
+    }
+    pub fn with_all_jobs(mission: &Mission) -> Self {
+        let mut menu = Self::new();
+        let mut job_names = mission.settings.jobs.keys().collect::<Vec<_>>();
+        job_names.sort();
+        let actions = job_names
+            .into_iter()
+            .map(|job_name| Action::Job(ConcreteJobRef::from_job_name(job_name).into()));
+        for action in actions {
+            let key = mission.settings.keybindings.shortest_key_for(&action);
+            menu.add_item(action, key);
+        }
+        menu
+    }
+    pub fn from_definition(
+        ActionMenuDefinition { intro, actions }: ActionMenuDefinition,
+        settings: &Settings,
+    ) -> Self {
+        let mut menu = Self::new();
+        if let Some(intro) = intro {
+            menu.set_intro(intro);
+        }
+        for action in actions {
+            let key = settings.keybindings.shortest_key_for(&action);
+            menu.add_item(action, key);
+        }
+        menu
+    }
+}

--- a/src/tui/menu/inform.rs
+++ b/src/tui/menu/inform.rs
@@ -1,0 +1,12 @@
+use super::*;
+
+static OK: &str = "OK";
+
+pub fn inform<S: Into<String>>(txt: S) -> Menu<&'static str> {
+    let mut menu = Menu::new();
+    menu.add_item(OK, None);
+    menu.state.set_intro(txt);
+    menu
+}
+
+pub type InformMenu = Menu<&'static str>;

--- a/src/tui/menu/menu_state.rs
+++ b/src/tui/menu/menu_state.rs
@@ -1,0 +1,137 @@
+use {
+    crokey::{
+        KeyCombination,
+        crossterm::event::{
+            MouseButton,
+            MouseEvent,
+            MouseEventKind,
+        },
+        key,
+    },
+    termimad::Area,
+};
+
+pub struct MenuItem<I> {
+    pub action: I,
+    pub area: Option<Area>,
+    pub key: Option<KeyCombination>,
+}
+
+pub struct MenuState<I> {
+    pub intro: Option<String>,
+    pub items: Vec<MenuItem<I>>,
+    pub selection: usize,
+    pub scroll: usize,
+}
+
+impl<I> Default for MenuState<I> {
+    fn default() -> Self {
+        Self {
+            intro: None,
+            items: Vec::new(),
+            selection: 0,
+            scroll: 0,
+        }
+    }
+}
+
+impl<I: ToString + Clone> MenuState<I> {
+    pub fn set_intro<S: Into<String>>(
+        &mut self,
+        intro: S,
+    ) {
+        self.intro = Some(intro.into());
+    }
+    pub fn add_item(
+        &mut self,
+        action: I,
+        key: Option<KeyCombination>,
+    ) {
+        self.items.push(MenuItem {
+            action,
+            area: None,
+            key,
+        });
+    }
+    pub fn clear_item_areas(&mut self) {
+        for item in self.items.iter_mut() {
+            item.area = None;
+        }
+    }
+    pub fn select(
+        &mut self,
+        selection: usize,
+    ) {
+        self.selection = selection.min(self.items.len());
+    }
+    pub(crate) fn fix_scroll(
+        &mut self,
+        page_height: usize,
+    ) {
+        let len = self.items.len();
+        let sel = self.selection;
+        if len <= page_height || sel < 3 || sel <= page_height / 2 {
+            self.scroll = 0;
+        } else if sel + 3 >= len {
+            self.scroll = len - page_height;
+        } else {
+            self.scroll = (sel - 2).min(len - page_height);
+        }
+    }
+    /// Handle a key event (not triggering the actions on their keys, only apply
+    /// the menu mechanics)
+    pub fn on_key(
+        &mut self,
+        key: KeyCombination,
+    ) -> Option<I> {
+        let items = &self.items;
+        if key == key!(down) {
+            self.selection = (self.selection + 1) % items.len();
+        } else if key == key!(up) {
+            self.selection = (self.selection + items.len() - 1) % items.len();
+        } else if key == key!(enter) {
+            return Some(items[self.selection].action.clone());
+        }
+        for item in &self.items {
+            if item.key == Some(key) {
+                return Some(item.action.clone());
+            }
+        }
+        None
+    }
+    pub fn item_idx_at(
+        &self,
+        x: u16,
+        y: u16,
+    ) -> Option<usize> {
+        for (idx, item) in self.items.iter().enumerate() {
+            if let Some(area) = &item.area {
+                if area.contains(x, y) {
+                    return Some(idx);
+                }
+            }
+        }
+        None
+    }
+    /// handle a mouse event, returning the triggered action if any (on
+    /// double click only)
+    pub fn on_mouse_event(
+        &mut self,
+        mouse_event: MouseEvent,
+        double_click: bool,
+    ) -> Option<I> {
+        let is_click = matches!(
+            mouse_event.kind,
+            MouseEventKind::Down(MouseButton::Left) | MouseEventKind::Up(MouseButton::Left),
+        );
+        if is_click {
+            if let Some(selection) = self.item_idx_at(mouse_event.column, mouse_event.row) {
+                self.selection = selection;
+                if double_click {
+                    return Some(self.items[self.selection].action.clone());
+                }
+            }
+        }
+        None
+    }
+}

--- a/src/tui/menu/menu_view.rs
+++ b/src/tui/menu/menu_view.rs
@@ -1,0 +1,150 @@
+use {
+    crate::*,
+    anyhow::Result,
+    crokey::{
+        KeyCombinationFormat,
+        crossterm::{
+            queue,
+            style::Print,
+        },
+    },
+    termimad::{
+        minimad::*,
+        *,
+    },
+};
+
+/// The drawer of the menu
+#[derive(Default)]
+pub struct MenuView {
+    available_area: Area,
+}
+
+impl MenuView {
+    fn compute_area_width(&self) -> u16 {
+        let screen = &self.available_area;
+        let sw2 = screen.width / 2;
+        let w2 = 24.min(sw2 - 3); // menu half width
+        w2 * 2
+    }
+    fn compute_area(
+        &self,
+        content_height: usize,
+        area_width: u16,
+    ) -> Area {
+        let screen = &self.available_area;
+        let ideal_height = content_height as u16 + 2; // margin of 1
+        let left = (screen.width - area_width) / 2;
+        let h = screen.height.min(ideal_height);
+        let top = ((screen.height - h) * 3 / 5).max(1);
+        Area::new(left, top, area_width, h)
+    }
+    pub fn set_available_area(
+        &mut self,
+        available_area: Area,
+    ) {
+        if available_area != self.available_area {
+            self.available_area = available_area;
+        }
+    }
+
+    /// Draw the menu and set the area of all visible items in the state
+    pub fn draw<I: ToString + Clone>(
+        &mut self,
+        w: &mut W,
+        state: &mut MenuState<I>,
+        skin: &BaconSkin,
+    ) -> Result<()> {
+        let key_format = KeyCombinationFormat::default().with_implicit_shift();
+        //.with_control("^");
+        state.clear_item_areas();
+        let mut md_skin = MadSkin::default();
+        md_skin
+            .paragraph
+            .set_fgbg(skin.menu_item_fg.color(), skin.menu_item_bg.color());
+        md_skin.italic.set_fg(skin.key_fg.color());
+        let mut sel_md_skin = MadSkin::default();
+        sel_md_skin.paragraph.set_fgbg(
+            skin.menu_item_selected_fg.color(),
+            skin.menu_item_selected_bg.color(),
+        );
+        sel_md_skin.italic.set_fg(skin.key_fg.color());
+        let area_width = self.compute_area_width();
+        let mut intro_lines = Vec::new();
+        let text_width = area_width - 2;
+        let intro = state.intro.clone();
+        let mut content_height = state.items.len();
+        if let Some(intro) = &intro {
+            let text = FmtText::from(&md_skin, intro, Some(text_width as usize));
+            intro_lines = text.lines;
+            content_height += intro_lines.len() + 1; // 1 for margin
+        }
+        let area = self.compute_area(content_height, area_width);
+        let h = area.height as usize - 2; // internal height
+        let scrollbar = compute_scrollbar(state.scroll, content_height, h, area.top + 1);
+        state.fix_scroll(h);
+        let mut rect = Rect::new(
+            area.clone(),
+            CompoundStyle::with_fgbg(skin.menu_border.color(), skin.menu_bg.color()),
+        );
+        rect.set_border_style(BORDER_STYLE_HALF_WIDTH_OUTSIDE);
+        rect.set_fill(true);
+        rect.draw(w)?;
+        let key_width = 8;
+        let mut label_width = area.width as usize - key_width - 2;
+        if scrollbar.is_some() {
+            label_width -= 1;
+        }
+        let mut y = area.top;
+        let mut items = state.items.iter_mut().enumerate().skip(state.scroll);
+        for _ in 0..h {
+            y += 1;
+            if !intro_lines.is_empty() {
+                let intro_line = intro_lines.remove(0);
+                goto(w, area.left + 1, y)?;
+                let dl = DisplayableLine::new(&md_skin, &intro_line, Some(text_width as usize));
+                queue!(w, Print(&dl))?;
+                if intro_lines.is_empty() {
+                    y += 1; // skip line for margin
+                }
+                continue;
+            }
+            if let Some((idx, item)) = items.next() {
+                let item_area = Area::new(area.left + 1, y, area.width - 2, 1);
+                let skin = if state.selection == idx {
+                    &sel_md_skin
+                } else {
+                    &md_skin
+                };
+                goto(w, item_area.left, y)?;
+                skin.write_composite_fill(
+                    w,
+                    Composite::from_inline(&item.action.to_string()),
+                    label_width,
+                    Alignment::Left,
+                )?;
+                let key_desc = item
+                    .key
+                    .map_or("".to_string(), |key| key_format.to_string(key));
+                skin.write_composite_fill(
+                    w,
+                    mad_inline!("*$0", &key_desc),
+                    key_width,
+                    Alignment::Right,
+                )?;
+                item.area = Some(item_area);
+            } else {
+                break;
+            }
+            if let Some((stop, sbottom)) = scrollbar {
+                goto(w, area.right() - 2, y)?;
+                if stop <= y && y <= sbottom {
+                    md_skin.scrollbar.thumb.queue(w)?;
+                } else {
+                    md_skin.scrollbar.track.queue(w)?;
+                }
+            }
+        }
+        Ok(())
+    }
+}

--- a/src/tui/menu/mod.rs
+++ b/src/tui/menu/mod.rs
@@ -1,0 +1,58 @@
+mod action_menu;
+mod inform;
+mod menu_state;
+mod menu_view;
+
+pub use {
+    action_menu::*,
+    inform::*,
+    menu_state::*,
+    menu_view::*,
+};
+
+use {
+    crate::*,
+    anyhow::Result,
+    crokey::KeyCombination,
+    termimad::Area,
+};
+
+pub struct Menu<I> {
+    pub state: MenuState<I>,
+    view: MenuView,
+}
+
+impl<I: ToString + Clone> Menu<I> {
+    pub fn new() -> Self {
+        Self {
+            state: Default::default(),
+            view: Default::default(),
+        }
+    }
+    pub fn draw(
+        &mut self,
+        w: &mut W,
+        skin: &BaconSkin,
+    ) -> Result<()> {
+        self.view.draw(w, &mut self.state, skin)
+    }
+    pub fn set_available_area(
+        &mut self,
+        area: Area,
+    ) {
+        self.view.set_available_area(area);
+    }
+    pub fn set_intro<S: Into<String>>(
+        &mut self,
+        intro: S,
+    ) {
+        self.state.set_intro(intro);
+    }
+    pub fn add_item(
+        &mut self,
+        action: I,
+        key: Option<KeyCombination>,
+    ) {
+        self.state.add_item(action, key);
+    }
+}

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1,7 +1,9 @@
 pub mod app;
 mod app_state;
+mod dialog;
 mod drawing;
 mod focus_file;
+mod menu;
 mod messages;
 mod scroll;
 mod search_state;
@@ -9,8 +11,10 @@ mod wrap;
 
 pub use {
     app_state::*,
+    dialog::*,
     drawing::*,
     focus_file::*,
+    menu::*,
     messages::*,
     scroll::*,
     search_state::*,

--- a/src/tui/search_state.rs
+++ b/src/tui/search_state.rs
@@ -153,18 +153,19 @@ impl SearchState {
     pub fn founds(&self) -> &[Found] {
         &self.founds
     }
-    /// Draw at the given position, with the specified width
+    /// Draw the input with its '/', at the given position, with the specified width
     pub fn draw_prefixed_input(
         &mut self,
         w: &mut W,
         x: u16,
         y: u16,
+        prefix_style: &str,
         width: u16, // must be > 1
     ) -> Result<()> {
         goto_line(w, y)?;
         draw(
             w,
-            CSI_FOUND,
+            prefix_style,
             if self.mode == SearchMode::ItemIdx {
                 ":"
             } else {
@@ -178,20 +179,19 @@ impl SearchState {
     pub fn add_summary_tstring(
         &self,
         t_line: &mut TLine,
+        style: &str,
     ) {
-        if self.input_has_content() {
-            if self.founds.is_empty() {
-                if self.mode == SearchMode::ItemIdx && self.is_invalid() {
-                    t_line.add_tstring(CSI_FOUND, "integer expected");
-                } else {
-                    t_line.add_tstring(CSI_FOUND, "no match");
-                }
+        if self.founds.is_empty() {
+            if self.mode == SearchMode::ItemIdx && self.is_invalid() {
+                t_line.add_tstring(style, "integer expected");
             } else {
-                t_line.add_tstring(
-                    CSI_FOUND,
-                    format!("{}/{}", self.selected_found + 1, self.founds.len(),),
-                );
+                t_line.add_tstring(style, "no match");
             }
+        } else {
+            t_line.add_tstring(
+                style,
+                format!("{}/{}", self.selected_found + 1, self.founds.len(),),
+            );
         }
     }
 }

--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -3,7 +3,7 @@
 
 All configuration files are optional but you'll probably need specific jobs for your targets, examples, etc.
 
-All accept the same properties (preferences, keybindings, jobs, etc.).
+All configuration files accept the same properties (preferences, keybindings, jobs, etc.).
 
 Bacon loads in order:
 
@@ -91,6 +91,7 @@ extraneous_args | if `false`, the action is run "as is" from `bacon.toml`, eg: n
 need_stdout |whether we need to capture stdout too (stderr is always captured) | `false`
 on_change_strategy | `wait_then_restart` or `kill_then_restart` |
 on_success | the action to run when there's no error, warning or test failures |
+skin | bacon application colors, [see below](#skin) |
 watch | a list of files and directories that will be watched if the job is run on a package. Usual source directories are implicitly included unless `default_watch` is set to false |
 workdir | overrides the execution directory |
 
@@ -287,7 +288,9 @@ Setting `listen = true` in the configuration makes bacon listen for commands on 
 
 Any action that can be bound to a key can also be sent on this socket, in text, one action per line.
 
-As a convenience, bacon can also be used to send those actions, eg `bacon --send 'scroll-lines(-2)'`.
+You can use standard unix programs. For example run `socat - UNIX-CONNECT:bacon.socket` then issue actions ending in new lines.
+
+Bacon can also be used to send those actions, eg `bacon --send 'scroll-lines(-2)'`.
 
 ## summary, wrap, reverse
 
@@ -330,3 +333,31 @@ on_failure = "play-sound(name=beep-warning,volume=100)"
 ```
 
 Sound name can be omitted. Possible values are `2`, `90s-game-ui-6`, `beep-6`, `beep-beep`, `beep-warning`, `bell-chord`, `car-horn`, `convenience-store-ring`, `cow-bells`, `pickup`, `positive-beeps`, `short-beep-tone`, `slash`, `store-scanner`, `success`.
+
+## Skin
+
+Most colors of the bacon application can be redefined in a `skin`, with colors being [8 bit ANSI values](https://en.wikipedia.org/wiki/ANSI_escape_code#8-bit).
+
+You can set colors within a `[skin]` object in any configuration file:
+
+```TOML
+[skin]
+status_fg = 251
+status_bg = 4
+key_fg = 11
+status_key_fg = 11
+project_name_badge_fg = 11
+project_name_badge_bg = 69
+```
+and you can override colors in a job:
+
+```TOML
+[jobs.test]
+command = ["cargo", "test"]
+need_stdout = true
+skin.status_bg = 6
+```
+
+All available skin entries, with meaning and default values, are listed in [src/conf/skin.rs](https://github.com/Canop/bacon/blob/main/src/conf/skin.rs#62).
+Skin entries may be added or removed in minor versions of bacon. Unrecognized entries are just ignored.
+

--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -177,6 +177,8 @@ help | <kbd>h</kbd> or <kbd>?</kbd> | open the help page
 job:job-reference | | execute the job with [job-reference](#job-references)
 next-match | <kbd>tab</kbd> | go to next search match
 no-op |  | do nothing (may be used to disable a previously set binding)
+open-menu(*menu-definition*) |  | open a user defined menu. For example<br>` "open-menu(intro=a text,actions=[job:ch,export:mx,quit])"`
+open-jobs-menu | <kbd>ctrl</kbd>-<kbd>j</kbd> | open a menu with all jobs
 pause |  | disable automatic job execution on change
 play-sound |  | play a [sound](#sound) with optional parameters, eg `play-sound(volume=100%)`
 previous-match | <kbd>backtab</kbd> | go to previous search match


### PR DESCRIPTION
This makes it possible to set up colors, either in the prefs, in a project's bacon.toml, or even in a specific job.
As usual, any color set overrides the default or any more global color.

Colors are set as ANSI codes. See https://en.wikipedia.org/wiki/ANSI_escape_code#8-bit

Example of configuration: 
```

[skin]
status_fg = 251
status_bg = 4
status_key_fg = 11
project_name_badge_fg = 11
project_name_badge_bg = 69
job_label_badge_bg = 166
warnings_badge_fg = 13
warnings_badge_bg = 15
computing_fg = 14
computing_bg = 232
search_input_prefix_fg = 88
found_fg = 88
found_selected_bg = 88

```

![image](https://github.com/user-attachments/assets/eafa5f05-4b8a-49d1-b12a-c44b45183a23)

Changing a color in a job:
```

[jobs.test]
command = ["cargo", "test"]
need_stdout = true
on_success = "play-sound(name=90s-game-ui-6,volume=50)"
on_failure = "play-sound(name=beep-warning,volume=100)"
skin.status_bg = 6
```

As it's difficult to change those entries once publicised, I'd welcome tests and comments before I merge this.


Fix #215 