### PR TITLE
chore: replace ASCII character 0xa0 (the 'NSBP' char), with a plain space char

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "AGPL-3.0"
 categories = ["command-line-utilities", "development-tools"]
 readme = "README.md"
 rust-version = "1.76"
-        
+
 [features]
 default = []
 clipboard = ["arboard"]
@@ -54,5 +54,5 @@ codegen-units = 1
 # termimad = { path = "../termimad" }
 # crokey = { path = "../crokey" }
 # coolor = { path = "../coolor" }
-# iq = { path = "../iq" }
+# iq = { path = "../iq" }
 # lazy-regex = { path = "../lazy-regex" }

--- a/defaults/default-bacon.toml
+++ b/defaults/default-bacon.toml
@@ -1,8 +1,8 @@
 # This is a configuration file for the bacon tool
 #
 # Complete help on configuration: https://dystroy.org/bacon/config/
-# 
-# You may check the current default at
+#
+# You may check the current default at
 #   https://github.com/Canop/bacon/blob/main/defaults/default-bacon.toml
 
 default_job = "check"

--- a/defaults/default-prefs.toml
+++ b/defaults/default-prefs.toml
@@ -42,7 +42,7 @@
 # Uncomment and change the value (true/false) to
 # set whether to display the count of changes since last job start
 #
-# show_changes_count = false
+# show_changes_count = false
 
 
 # Uncomment one of those lines if you don't want the default
@@ -74,12 +74,12 @@ line_format = "{kind} {path}:{line}:{column} {message}"
 
 # If you want some job to emit a beep on success or on failure,
 # you need to globally enable sound, and you may set up the max volume here
-# 
+#
 # With sound enabled, you may set up sound on a job with eg
 #    on_success = "play-sound(name=90s-game-ui-6,volume=50)"
 #    on_failure = "play-sound(name=beep-warning,volume=100)"
 [sound]
-enabled = false # set true to allow sound
+enabled = false # set true to allow sound
 base_volume = "100%" # global volume multiplier
 
 # Uncomment and change the key-bindings you want to define

--- a/website/docs/analyzers.md
+++ b/website/docs/analyzers.md
@@ -6,7 +6,7 @@ This page is an overview of the supported tools and how bacon can be configured 
 
 # Summary
 
-Analyzer | Languages | Tool
+Analyzer | Languages | Tool
 -|-|-
 [standard](#rust) (*default*) | Rust | [cargo](https://doc.rust-lang.org/cargo/) `check`, `build`, `test`, `clippy`, `doc`, `run`, `miri`
 [nextest](#nextest)| Rust |  [cargo-nextest](https://nexte.st/)

--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -227,7 +227,7 @@ job reference | meaning
 `job:previous` | the job which ran before, if any. The `back` action has usually the same effect
 `job:previous-or-quit` | same as `job:previous`, but will quit if there was no job. The `back-or-quit` action has usually the same effect
 
-# Exports
+# Exports
 
 If necessary, exports can be defined to write files either on end of task or on key presses.
 


### PR DESCRIPTION
Some files have a weird `0xa0` char, which get rendered as a space. This PR will replace them with a plain space char.