### PR TITLE
Remove stray apostrophe from example for kill command

### DIFF
--- a/defaults/default-bacon.toml
+++ b/defaults/default-bacon.toml
@@ -94,7 +94,7 @@ need_stdout = true
 allow_warnings = true
 background = false
 on_change_strategy = "kill_then_restart"
-# kill = ["pkill", "-TERM", "-P"]'
+# kill = ["pkill", "-TERM", "-P"]
 
 # This parameterized job runs the example of your choice, as soon
 # as the code compiles.


### PR DESCRIPTION
(thanks for this awesome tool!)