### PR TITLE
feat: support different file type paths in eslint analyzer

### DIFF
--- a/src/analysis/eslint/eslint_line_analyzer.rs
+++ b/src/analysis/eslint/eslint_line_analyzer.rs
@@ -113,7 +113,7 @@ pub fn get_location_path(content: &TLine) -> Option<String> {
     }
     // trying to recognize a path, I might make some wrong assumptions here,
     // especially for windows...
-    if !regex_is_match!(r"^\s*/\S+\.\w+s\s*$", &first.raw) {
+    if !regex_is_match!(r"^\s*/\S+\.\w+\s*$", &first.raw) {
         return None;
     }
     Some(first.raw.to_string())


### PR DESCRIPTION
Update eslint location regex to match `jsx`, `vue` and any other extensions.

fixes #377 

<img width="1090" height="258" alt="image" src="https://github.com/user-attachments/assets/e2b6d9c2-7ae6-4301-a45b-2685032a4c75" />
