### PR TITLE
support tests passing with output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ### next
-- allow more any file extension in eslint analyzer - Fix #377 - Thanks @meepleek
+- allow any file extension in eslint analyzer - Fix #377 - Thanks @meepleek
 
 <a name="v3.16.0"></a>
 ### v3.16.0 - 2025/06/14

--- a/src/analysis/cargo_json/mod.rs
+++ b/src/analysis/cargo_json/mod.rs
@@ -58,7 +58,7 @@ impl Analyzer for CargoJsonAnalyzer {
                 self.receive_cargo_message(message, cmd_line.origin, command_output);
             }
             Err(err) => {
-                let line = TLine::from_tty(&format!("Error parsing JSON: {}", err));
+                let line = TLine::from_tty(&format!("Error parsing JSON: {err}"));
                 let cmd_line = CommandOutputLine {
                     content: line,
                     origin: cmd_line.origin,

--- a/src/analysis/item_accumulator.rs
+++ b/src/analysis/item_accumulator.rs
@@ -36,7 +36,7 @@ impl ItemAccumulator {
             Some(Kind::Warning) => self.warnings.push(line),
             Some(Kind::Error) => self.errors.push(line),
             Some(Kind::TestFail) => self.test_fails.push(line),
-            _ => {} // before warnings and errors, or in a sum
+            _ => {} // before warnings and errors, or in a sum, or test output
         }
     }
     pub fn push_error_title(

--- a/src/analysis/line_type.rs
+++ b/src/analysis/line_type.rs
@@ -18,6 +18,8 @@ pub enum Kind {
     Error,
     /// a test failure
     TestFail,
+    /// a test output (may be a failure, or just --show-output)
+    TestOutput,
     /// a sum of errors and/or warnings, typically occurring
     /// at the end of the compilation of a package
     Sum,
@@ -104,21 +106,16 @@ impl LineType {
     ) -> Result<()> {
         match self {
             Self::Title(Kind::Error) => {
-                write!(w, "{}", format!("{:^3}", item_idx).black().bold().on_red())?;
+                write!(w, "{}", format!("{item_idx:^3}").black().bold().on_red())?;
             }
-            Self::Title(Kind::TestFail) => {
+            Self::Title(Kind::TestFail | Kind::TestOutput) => {
                 write!(
                     w,
-                    "\u{1b}[1m\u{1b}[38;5;235m\u{1b}[48;5;208m{:^3}\u{1b}[0m\u{1b}[0m",
-                    item_idx
+                    "\u{1b}[1m\u{1b}[38;5;235m\u{1b}[48;5;208m{item_idx:^3}\u{1b}[0m\u{1b}[0m"
                 )?;
             }
             Self::Title(Kind::Warning) => {
-                write!(
-                    w,
-                    "{}",
-                    format!("{:^3}", item_idx).black().bold().on_yellow()
-                )?;
+                write!(w, "{}", format!("{item_idx:^3}").black().bold().on_yellow())?;
             }
             _ => {}
         }

--- a/src/analysis/python/ruff.rs
+++ b/src/analysis/python/ruff.rs
@@ -98,7 +98,7 @@ pub fn build_report(cmd_lines: &[CommandOutputLine]) -> anyhow::Result<Report> {
             items.push_error_title(burp::error_line_ts(message));
             items.push_line(
                 LineType::Location,
-                burp::location_line(format!("{}:{}:{}", path, line, column)),
+                burp::location_line(format!("{path}:{line}:{column}")),
             );
             last_is_blank = false;
         } else {

--- a/src/analysis/standard/standard_line_analyser.rs
+++ b/src/analysis/standard/standard_line_analyser.rs
@@ -29,9 +29,9 @@ fn analyze_line(cmd_line: &CommandOutputLine) -> LineAnalysis {
         if let Some((k, r)) = as_test_result(content) {
             key = Some(k.to_string());
             LineType::TestResult(r)
-        } else if let Some(k) = as_fail_result_title(content) {
+        } else if let Some(k) = as_test_stdout_title(content) {
             key = Some(k.to_string());
-            LineType::Title(Kind::TestFail)
+            LineType::Title(Kind::TestOutput)
         } else if let Some(k) = as_stack_overflow_message(content) {
             key = Some(k.to_string());
             LineType::Title(Kind::TestFail)
@@ -203,7 +203,7 @@ fn as_test_result(s: &str) -> Option<(&str, bool)> {
         "ok" => Some((key, true)),
         "FAILED" => Some((key, false)),
         other => {
-            warn!("unrecognized doctest outcome: {:?}", other);
+            warn!("unrecognized doctest outcome: {other:?}");
             None
         }
     })
@@ -211,7 +211,7 @@ fn as_test_result(s: &str) -> Option<(&str, bool)> {
 
 /// return Some(key) when the line is like this:
 /// "---- key stdout ----"
-fn as_fail_result_title(s: &str) -> Option<&str> {
+fn as_test_stdout_title(s: &str) -> Option<&str> {
     regex_captures!(r#"^---- (.+) stdout ----$"#, s).map(|(_, key)| key)
 }
 

--- a/src/analysis/swift/lint.rs
+++ b/src/analysis/swift/lint.rs
@@ -72,7 +72,7 @@ impl Analyzer for SwiftLintAnalyzer {
                 );
 
                 if let Some(rule) = diagnostic.rule {
-                    items.push_line(LineType::Normal, TLine::from_raw(format!("Rule: {}", rule)));
+                    items.push_line(LineType::Normal, TLine::from_raw(format!("Rule: {rule}")));
                 }
             } else {
                 items.push_line(LineType::Normal, line.content.clone());

--- a/src/conf/action.rs
+++ b/src/conf/action.rs
@@ -145,8 +145,8 @@ impl fmt::Display for Action {
         f: &mut fmt::Formatter,
     ) -> fmt::Result {
         match self {
-            Self::Export(name) => write!(f, "export:{}", name),
-            Self::Job(job_ref) => write!(f, "job:{}", job_ref),
+            Self::Export(name) => write!(f, "export:{name}"),
+            Self::Job(job_ref) => write!(f, "job:{job_ref}"),
             Self::Back => write!(f, "back"),
             Self::BackOrQuit => write!(f, "back-or-quit"),
             Self::CopyUnstyledOutput => write!(f, "copy-unstyled-output"),
@@ -191,9 +191,9 @@ impl fmt::Display for Action {
             Self::PlaySound(PlaySoundCommand { name, volume }) => {
                 write!(f, "play-sound(")?;
                 if let Some(name) = name {
-                    write!(f, "name={},", name)?;
+                    write!(f, "name={name},")?;
                 }
-                write!(f, "volume={})", volume)
+                write!(f, "volume={volume})")
             }
         }
     }

--- a/src/conf/config.rs
+++ b/src/conf/config.rs
@@ -75,13 +75,13 @@ impl Config {
     /// Load a configuration item filling the provided path in TOML
     pub fn from_path(path: &Path) -> Result<Self> {
         let conf = toml::from_str::<Self>(&fs::read_to_string(path)?)
-            .with_context(|| format!("Failed to parse configuration file at {:?}", path))?;
+            .with_context(|| format!("Failed to parse configuration file at {path:?}"))?;
         for (name, job) in &conf.jobs {
             if !regex_is_match!(r#"^[\w-]+$"#, name) {
-                bail!("Invalid configuration : Illegal job name : {:?}", name);
+                bail!("Invalid configuration : Illegal job name : {name:?}");
             }
             if job.command.is_empty() {
-                bail!("Invalid configuration : empty command for job {:?}", name);
+                bail!("Invalid configuration : empty command for job {name:?}");
             }
         }
         Ok(conf)

--- a/src/conf/settings.rs
+++ b/src/conf/settings.rs
@@ -102,7 +102,7 @@ impl Settings {
             if path.exists() {
                 let configs = Config::from_path_detect(&path)?;
                 if !configs.is_empty() {
-                    info!("config loaded from {:?}", path);
+                    info!("config loaded from {path:?}");
                     settings.register_config_file(path.clone());
                     for config in configs {
                         settings.apply_config(&config);

--- a/src/tty/mod.rs
+++ b/src/tty/mod.rs
@@ -12,6 +12,7 @@ pub const CSI_GREEN: &str = "\u{1b}[32m";
 pub const CSI_RED: &str = "\u{1b}[31m";
 pub const CSI_BOLD_RED: &str = "\u{1b}[1m\u{1b}[38;5;9m";
 pub const CSI_BOLD_ORANGE: &str = "\u{1b}[1m\u{1b}[38;5;208m";
+pub const CSI_BOLD_GREEN: &str = "\u{1b}[1m\u{1b}[38;5;34m";
 
 /// Used for "Blocking"
 pub const CSI_BLUE: &str = "\u{1b}[1m\u{1b}[36m";

--- a/src/tty/tline.rs
+++ b/src/tty/tline.rs
@@ -124,6 +124,21 @@ impl TLine {
         }
         TLine { strings }
     }
+    pub fn passed(key: &str) -> Self {
+        let mut strings = Vec::with_capacity(4);
+        strings.push(TString::new(CSI_BOLD_GREEN, "passed"));
+        strings.push(TString::new("", ": "));
+        if let Some((module, function)) = key.rsplit_once("::") {
+            strings.push(TString {
+                csi: "".to_string(),
+                raw: format!("{module}::"),
+            });
+            strings.push(TString::new(CSI_BOLD_GREEN, function));
+        } else {
+            strings.push(TString::new(CSI_BOLD_GREEN, key));
+        }
+        TLine { strings }
+    }
     pub fn add_badge(
         &mut self,
         badge: TString,


### PR DESCRIPTION
Before this, tests passing but with an output due to --show-output were supposed failing.

Fix #379