### PR TITLE
allow hiding of scrollbar for improved select/copy/paste support

### DIFF
--- a/src/conf/config.rs
+++ b/src/conf/config.rs
@@ -3,11 +3,7 @@ use {
     anyhow::*,
     lazy_regex::regex_is_match,
     serde::Deserialize,
-    std::{
-        collections::HashMap,
-        fs,
-        path::Path,
-    },
+    std::{collections::HashMap, fs, path::Path},
 };
 
 /// A configuration item which may be stored in various places, eg as `bacon.toml`
@@ -53,6 +49,8 @@ pub struct Config {
     pub listen: Option<bool>,
 
     pub wrap: Option<bool>,
+
+    pub hide_scrollbar: Option<bool>,
 }
 
 impl Config {

--- a/src/conf/settings.rs
+++ b/src/conf/settings.rs
@@ -1,13 +1,7 @@
 use {
     crate::*,
-    anyhow::{
-        Result,
-        bail,
-    },
-    std::{
-        collections::HashMap,
-        path::PathBuf,
-    },
+    anyhow::{Result, bail},
+    std::{collections::HashMap, path::PathBuf},
 };
 
 /// The settings used in the application.
@@ -35,6 +29,8 @@ pub struct Settings {
     /// Whether to listen for actions on a unix socket (if on unix)
     pub listen: bool,
     pub all_jobs: Job,
+    /// Whether to hide the scrollbar, allowing copy-pasting of the output.
+    pub hide_scrollbar: bool,
 }
 
 impl Default for Settings {
@@ -57,6 +53,7 @@ impl Default for Settings {
             config_files: Default::default(),
             listen: false,
             all_jobs: Default::default(),
+            hide_scrollbar: false,
         }
     }
 }
@@ -137,6 +134,9 @@ impl Settings {
         config: &Config,
     ) {
         self.all_jobs.apply(&config.all_jobs);
+        if let Some(b) = config.hide_scrollbar {
+            self.hide_scrollbar = b;
+        }
         if let Some(b) = config.summary {
             self.summary = b;
         }

--- a/src/tui/app_state.rs
+++ b/src/tui/app_state.rs
@@ -2,27 +2,14 @@ use {
     crate::*,
     anyhow::Result,
     crokey::KeyCombination,
-    std::{
-        io::Write,
-        process::ExitStatus,
-        time::Instant,
-    },
+    std::{io::Write, process::ExitStatus, time::Instant},
     termimad::{
-        Area,
-        CompoundStyle,
-        MadSkin,
+        Area, CompoundStyle, MadSkin,
         crossterm::{
-            cursor,
-            execute,
-            style::{
-                Attribute,
-                Print,
-            },
+            cursor, execute,
+            style::{Attribute, Print},
         },
-        minimad::{
-            Alignment,
-            Composite,
-        },
+        minimad::{Alignment, Composite},
     },
 };
 
@@ -65,6 +52,8 @@ pub struct AppState<'s> {
     help_page: Option<HelpPage>,
     /// display the raw output instead of the report
     raw_output: bool,
+    /// whether the scrollbar is hidden
+    hide_scrollbar: bool,
     /// whether auto-refresh is enabled
     pub auto_refresh: AutoRefresh,
     /// How many watch events were received since last job start
@@ -123,6 +112,7 @@ impl<'s> AppState<'s> {
             top_item_idx: 0,
             help_line,
             help_page: None,
+            hide_scrollbar: mission.settings.hide_scrollbar,
             mission,
             raw_output: false,
             auto_refresh: AutoRefresh::Enabled,
@@ -841,7 +831,11 @@ impl<'s> AppState<'s> {
         ); // bold, colored background
         let area = Area::new(0, y, self.width - 1, self.page_height() as u16);
         let content_height = self.content_height();
-        let scrollbar = area.scrollbar(self.scroll, content_height);
+        let scrollbar = if self.hide_scrollbar {
+            None
+        } else {
+            area.scrollbar(self.scroll, content_height)
+        };
         let mut top_item_idx = None;
         let top = if self.reverse && self.page_height() > content_height {
             self.page_height() - content_height


### PR DESCRIPTION
This commit allows setting the `hide_scrollbar = true` value.

This removes the rendered scrollbar in the content view. This is done because I often copy-paste information from Bacon (test diffs using `pretty_assertions`, or errors to paste into a search or chat field, etc), but if there is scrollable content, copy/pasting the lines means the scrollbar characters get copied as well, garbling the output,

Hiding the scrollbar obviously means you lose the signal that there is more content below the fold, but it's a conscious decision you make by hiding the scrollbar, and not one I am personally concerned about.

Either way, there are more ways to tackle this than one, so I'm happy to revise if you want a different solution.