### PR TITLE
Support more 4-bit colours in `rustc` analyser

### DIFF
--- a/src/analysis/standard/standard_line_analyser.rs
+++ b/src/analysis/standard/standard_line_analyser.rs
@@ -77,12 +77,12 @@ fn analyze_line(cmd_line: &CommandOutputLine) -> LineAnalysis {
                     body.csi.as_ref(),
                     body.raw.as_ref(),
                 ) {
-                    (CSI_BOLD_RED, "error", CSI_ERROR_BODY, body_raw)
+                    (CSI_BOLD_RED | CSI_BOLD_4BIT_RED, "error", CSI_ERROR_BODY, body_raw)
                         if body_raw.starts_with(": aborting due to") =>
                     {
                         LineType::Title(Kind::Sum)
                     }
-                    (CSI_BOLD_RED, title_raw, CSI_ERROR_BODY, _)
+                    (CSI_BOLD_RED | CSI_BOLD_4BIT_RED, title_raw, CSI_ERROR_BODY, _)
                         if title_raw.starts_with("error") =>
                     {
                         LineType::Title(Kind::Error)
@@ -95,10 +95,14 @@ fn analyze_line(cmd_line: &CommandOutputLine) -> LineAnalysis {
                     (CSI_BOLD_YELLOW | CSI_BOLD_4BIT_YELLOW, "warning", _, body_raw) => {
                         determine_warning_type(body_raw, content)
                     }
-                    ("", title_raw, CSI_BOLD_BLUE, "--> ") if is_spaces(title_raw) => {
+                    ("", title_raw, CSI_BOLD_BLUE | CSI_BOLD_4BIT_BLUE, "--> ")
+                        if is_spaces(title_raw) =>
+                    {
                         LineType::Location
                     }
-                    ("", title_raw, CSI_BOLD_BLUE, "::: ") if is_spaces(title_raw) => {
+                    ("", title_raw, CSI_BOLD_BLUE | CSI_BOLD_4BIT_BLUE, "::: ")
+                        if is_spaces(title_raw) =>
+                    {
                         LineType::Location
                     }
                     ("", k, CSI_BOLD_RED | CSI_RED, "FAILED") if content.strings.len() == 2 => {

--- a/src/tty/mod.rs
+++ b/src/tty/mod.rs
@@ -11,6 +11,7 @@ pub const CSI_GREEN: &str = "\u{1b}[32m";
 
 pub const CSI_RED: &str = "\u{1b}[31m";
 pub const CSI_BOLD_RED: &str = "\u{1b}[1m\u{1b}[38;5;9m";
+pub const CSI_BOLD_4BIT_RED: &str = "\u{1b}[1m\u{1b}[91m";
 pub const CSI_BOLD_ORANGE: &str = "\u{1b}[1m\u{1b}[38;5;208m";
 pub const CSI_BOLD_GREEN: &str = "\u{1b}[1m\u{1b}[38;5;34m";
 
@@ -26,6 +27,8 @@ pub const CSI_BOLD_YELLOW: &str = "\u{1b}[1m\u{1b}[33m";
 pub const CSI_BOLD_BLUE: &str = "\u{1b}[1m\u{1b}[38;5;14m";
 #[cfg(not(windows))]
 pub const CSI_BOLD_BLUE: &str = "\u{1b}[1m\u{1b}[38;5;12m";
+#[cfg(not(windows))]
+pub const CSI_BOLD_4BIT_BLUE: &str = "\u{1b}[1m\u{1b}[94m";
 
 #[cfg(windows)]
 pub const CSI_BOLD_4BIT_YELLOW: &str = "\u{1b}[1m\u{1b}[33m";


### PR DESCRIPTION
Corresponding `rustc` change: https://github.com/rust-lang/rust/pull/147207

Resolves #399.