### PR TITLE
Allow thread ID when parsing panic messages

### DIFF
--- a/src/analysis/nextest/nextest_line_analyser.rs
+++ b/src/analysis/nextest/nextest_line_analyser.rs
@@ -187,7 +187,7 @@ fn is_location_v3(content: &TLine) -> bool {
         return false;
     }
     regex_is_match!(
-        r#"^\s*thread '.+' panicked at [^:\s'"]+:\d+:\d+:$"#,
+        r#"^\s*thread '.+'( \(\d+\))? panicked at [^:\s'"]+:\d+:\d+:$"#,
         &ts.raw
     )
 }

--- a/src/analysis/standard/standard_line_analyser.rs
+++ b/src/analysis/standard/standard_line_analyser.rs
@@ -60,7 +60,7 @@ fn analyze_line(cmd_line: &CommandOutputLine) -> LineAnalysis {
         } else if regex_is_match!(r#"^\s+--> [^:\s'"]+:\d+:\d+$"#, content) {
             // this comes up in test failures to compile
             LineType::Location
-        } else if regex_is_match!(r#"^thread '.+' panicked at [^:\s'"]+:\d+:\d+:$"#, content) {
+        } else if regex_is_match!(r#"^thread '.+'( \(\d+\))? panicked at [^:\s'"]+:\d+:\d+:$"#, content) {
             // this comes up in test failures
             LineType::Location
         } else {
@@ -122,7 +122,7 @@ fn analyze_line(cmd_line: &CommandOutputLine) -> LineAnalysis {
             }
             (Some(content), None) => {
                 if regex_is_match!(
-                    r#"^\s*thread '.+' panicked at [^:\s'"]+:\d+:\d+:$"#,
+                    r#"^\s*thread '.+'( \(\d+\))? panicked at [^:\s'"]+:\d+:\d+:$"#,
                     &content.raw
                 ) {
                     // this comes up in nextest failures


### PR DESCRIPTION
As of Rust 1.91, panic messages will include the thread ID of the panicking thread: https://github.com/rust-lang/rust/pull/115746