### PR TITLE
Fix race condition between child process closing `stderr` and reading the exit code

### DIFF
--- a/src/exec/executor.rs
+++ b/src/exec/executor.rs
@@ -199,7 +199,7 @@ impl MissionExecutor {
             match stop_receiver.recv() {
                 Ok(stop) => match stop {
                     StopMessage::SendStatus => {
-                        let status = child.try_wait();
+                        let status = child.wait();
                         if let Ok(status) = status {
                             let _ = line_sender.send(CommandExecInfo::End { status });
                         }

--- a/src/result/command_output.rs
+++ b/src/result/command_output.rs
@@ -37,7 +37,7 @@ pub struct CommandOutput {
 #[derive(Debug)]
 pub enum CommandExecInfo {
     /// Command ended
-    End { status: Option<ExitStatus> },
+    End { status: ExitStatus },
 
     /// Bacon killed the command
     Interruption,

--- a/src/result/command_result.rs
+++ b/src/result/command_result.rs
@@ -22,10 +22,10 @@ pub enum CommandResult {
 impl CommandResult {
     pub fn build(
         output: CommandOutput,
-        exit_status: Option<ExitStatus>,
+        exit_status: ExitStatus,
         mut report: Report,
     ) -> Result<Self> {
-        let error_code = exit_status.and_then(|s| s.code()).filter(|&c| c != 0);
+        let error_code = exit_status.code().filter(|&c| c != 0);
         debug!("report stats: {:?}", &report.stats);
         if let Some(error_code) = error_code {
             let stats = &report.stats;

--- a/src/result/report_maker.rs
+++ b/src/result/report_maker.rs
@@ -51,7 +51,7 @@ impl ReportMaker {
     pub fn build_result(
         &mut self,
         output: CommandOutput,
-        exit_status: Option<ExitStatus>,
+        exit_status: ExitStatus,
     ) -> Result<CommandResult> {
         let report = self.analyzer.build_report()?;
         let result = CommandResult::build(output, exit_status, report)?;

--- a/src/tui/mission_state.rs
+++ b/src/tui/mission_state.rs
@@ -427,7 +427,7 @@ impl<'a, 'm> MissionState<'a, 'm> {
     }
     pub fn finish_task(
         &mut self,
-        exit_status: Option<ExitStatus>,
+        exit_status: ExitStatus,
     ) -> Result<()> {
         let output = self.take_output().unwrap_or_default();
         let result = self.report_maker.build_result(output, exit_status)?;


### PR DESCRIPTION
This fixes the issue reported in #403, but only for processes that close `stderr` as part of their shutdown. When the child process closes `stderr` early, this will still cause `bacon` to freeze (see #403 for a small reproduction), but it will no longer ignore all further output on `stdout`.