### PR TITLE
update nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -52,11 +52,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1736320768,
-        "narHash": "sha256-nIYdTAiKIGnFNugbomgBJR+Xv5F1ZQU+HfaBqJKroC0=",
+        "lastModified": 1764384123,
+        "narHash": "sha256-UoliURDJFaOolycBZYrjzd9Cc66zULEyHqGFH3QHEq0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4bc9c909d9ac828a039f288cf872d16d38185db8",
+        "rev": "59b6c96beacc898566c9be1052ae806f3835f87d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
The rust compiler in the current pinned version of nixpkgs is not compatible with the current state of the project. I opened a similar PR for https://github.com/crisidev/bacon-ls/pull/87. Here is the full error for reference:
```
error: Cannot build '/nix/store/ny3zrmh19ks5sxr3ygy49p14sx1qfdj9-bacon-deps-3.20.1.drv'.
       Reason: builder failed with exit code 101.
       Output paths:
         /nix/store/2iac7aj8ch5r832jmdzq16s6i48247xv-bacon-deps-3.20.1
       Last 25 log lines:
       > [naersk] CARGO_BUILD_RUSTFLAGS:
       > [naersk] CARGO_BUILD_RUSTFLAGS (updated):  --remap-path-prefix /nix/store/7xxw4q0vjh0gslq3wykk89gissgcl9im-crates-io-dependencies=/sources --remap-path-prefix /nix/store/ddf1s2ajwli6qbxwq1bnad1sxdzmb7f7-git-dependencies=/sources
       > Running phase: buildPhase
       > cargo build $cargo_release -j "$NIX_BUILD_CORES" --message-format=$cargo_message_format
       > error: failed to get `anyhow` as a dependency of package `bacon v3.20.1 (/nix/var/nix/builds/nix-38127-2199272316/dummy-src)`
       >
       > Caused by:
       >   failed to load source for dependency `anyhow`
       >
       > Caused by:
       >   Unable to update registry `crates-io`
       >
       > Caused by:
       >   failed to update replaced source registry `crates-io`
       >
       > Caused by:
       >   failed to parse manifest at `/nix/store/7xxw4q0vjh0gslq3wykk89gissgcl9im-crates-io-dependencies/coreaudio-sys-0.2.17-ceec7a6067e62d6f931a2baf6f3a751f4a892595bcec1461a3c94ef9949864b6/Cargo.toml`
       >
       > Caused by:
       >   feature `edition2024` is required
       >
       >   The package requires the Cargo feature called `edition2024`, but that feature is not stabilized in this version of Cargo (1.83.0 (5ffbef321 2024-10-29)).
       >   Consider trying a more recent nightly release.
       >   See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#edition-2024 for more information about the status of this feature.
       > [naersk] cargo returned with exit code 101, exiting
       For full logs, run:
         nix log /nix/store/ny3zrmh19ks5sxr3ygy49p14sx1qfdj9-bacon-deps-3.20.1.drv
error: Cannot build '/nix/store/2vkgn2d8vwxfrlh0rfz1lk4ay7rspfc4-bacon-3.20.1.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/4ilc52qgg1xxn8ivp5z9sn3j18br0hfl-bacon-3.20.1
```