### PR TITLE
don't show no-op keybindings in help

### DIFF
--- a/src/help/help_page.rs
+++ b/src/help/help_page.rs
@@ -63,6 +63,7 @@ impl HelpPage {
             .keybindings
             .build_reverse_map()
             .into_iter()
+            .filter(|(action, _)| **action != Action::NoOp)
             .map(|(action, cks)| {
                 let cks: Vec<String> = cks.iter().map(|ck| format!("*{ck}*")).collect();
                 let cks = cks.join(" or ");


### PR DESCRIPTION
Fix #416