### PR TITLE
feat: support negative `!pattern` syntax in ignore to override .gitignore

### DIFF
--- a/src/ignorer/glob_ignorer.rs
+++ b/src/ignorer/glob_ignorer.rs
@@ -1,4 +1,5 @@
 use {
+    super::build_glob_patterns,
     crate::*,
     anyhow::Result,
     std::path::Path,
@@ -15,17 +16,7 @@ impl GlobIgnorer {
         pattern: &str,
         root: &Path,
     ) -> Result<()> {
-        if pattern.starts_with('/') {
-            self.globs.push(glob::Pattern::new(pattern)?);
-            // it's probably a path relative to the root of the package
-            let pattern = root.join(pattern);
-            let pattern = pattern.to_string_lossy();
-            self.globs.push(glob::Pattern::new(&pattern)?);
-        } else {
-            // as glob doesn't work with non absolute paths, we make it absolute
-            self.globs
-                .push(glob::Pattern::new(&format!("/**/{pattern}"))?);
-        }
+        self.globs.extend(build_glob_patterns(pattern, root)?);
         Ok(())
     }
 }

--- a/src/jobs/job.rs
+++ b/src/jobs/job.rs
@@ -66,7 +66,9 @@ pub struct Job {
     /// Whether to hide the scrollbar
     pub hide_scrollbar: Option<bool>,
 
-    /// A list of glob patterns to ignore
+    /// A list of glob patterns to ignore.
+    /// Patterns starting with `!` are negations that force-include
+    /// matching paths, overriding other ignore rules (including .gitignore).
     #[serde(default)]
     pub ignore: Vec<String>,
 
@@ -275,7 +277,7 @@ fn test_job_apply() {
         expand_env_vars: Some(false),
         extraneous_args: Some(false),
         hide_scrollbar: Some(true),
-        ignore: vec!["special-target".to_string(), "generated".to_string()],
+        ignore: vec!["special-target".to_string(), "generated".to_string(), "!myfile.txt".to_string()],
         ignored_lines: Some(vec![LinePattern::from_str("half-error.*").unwrap()]),
         kill: Some(vec!["die".to_string()]),
         need_stdout: Some(true),

--- a/website/src/config.md
+++ b/website/src/config.md
@@ -84,7 +84,7 @@ default_watch | whether to watch default files (`src`, `tests`, `examples`, `bui
 env | a map of environment vars, for example `env.LOG_LEVEL="die"` |
 hide_scrollbar | whether to hide the scrollbar (for easier select & copy) | `false`
 kill | a command replacing the default job interruption (platform dependant, `SIGKILL` on unix). For example `kill = ["kill", "-s", "INT"]` |
-ignore | list of glob patterns for files to ignore |
+ignore | list of glob patterns for files to ignore. Patterns starting with `!` are negations that force-include matching paths, overriding other ignore rules (including `.gitignore`) |
 ignored_lines | regular expressions for lines to ignore |
 extraneous_args | if `false`, the action is run "as is" from `bacon.toml`, eg: no `--all-features` or `--features` inclusion | `true`
 need_stdout |whether we need to capture stdout too (stderr is always captured) | `false`


### PR DESCRIPTION
Adds support for `!pattern` syntax in the `ignore` config field to override gitignore rules.

```toml
watch = ["."]
ignore = ["!.env"]
```

Fixes #308.
