### PR TITLE
DOC/WEB: Add description and link to emacs-bacon

### DIFF
--- a/website/ddoc.hjson
+++ b/website/ddoc.hjson
@@ -14,6 +14,7 @@ site-map: {
         FAQ: community/FAQ.md
         bacon-ls: community/bacon-ls.md
         nvim-bacon: community/nvim-bacon.md
+        emacs-bacon: community/emacs-bacon.md
     }
 }
 

--- a/website/src/community/emacs-bacon.md
+++ b/website/src/community/emacs-bacon.md
@@ -1,0 +1,56 @@
+
+
+# Purpose
+
+[emacs-bacon](https://seed.pipapo.org/nodes/seed.pipapo.org/rad:zKbD2Y9kERBYScgczMaJBTRfjBhh)
+is a emacs minor-mode, which, combined with bacon, lets you navigate between errors and
+warnings without leaving your editor, just hitting a key. It also syncronizes bacon to show
+the current navigated item.
+
+# Development
+
+emacs-bacon is maintained [radicle](https://radicle.xyz/). Issues and PR's are maintained in
+[radicle](https://radicle.xyz/guides/user#2-collaborating-the-radicle-way) as well.
+
+Discussions and feedback are welcome on mastodon. Send to `@cehteh@social.tchncs.de` with the
+`#scrollpanel` tag.
+
+
+# How it works
+
+At every job end, bacon writes a `.bacon-locations` file with all items (errors, warnings,
+test failures, etc.) and for each of them its label, file path, line and column.
+
+It read the `bacon/prefs.toml` and local `bacon.toml`. You can remote-control bacon from emacs
+with the `C-c b` prefix (customizeable) followed by whatever keybindings the bacon preferences
+define to send a command to bacon.
+
+You can bind `bacon-next` and other commands to jump to next|prev|first
+items|error|warning|test. bacon-minor-mode watches the `.bacon-locations` file for changes and
+re-reads it every time it changed.
+
+When jumping to a location, emacs-bacon also sends a command to bacon to scroll to the focused item.
+
+# Bacon configuration
+
+The configuration instructing bacon to export the locations at every job should be defined in
+your global `bacon/prefs.toml`:
+
+```TOML
+[exports.locations]
+auto = true
+path = ".bacon-locations"
+line_format = "{kind}@{job}[{item_idx}] {path}:{line}:{column} {message}"
+```
+
+In order for emacs-bacon to send commands to bacon, you should also ask it to listen, with
+
+```toml
+listen = true
+```
+
+# Installation & Usage
+
+More details on how to install emacs-bacon, how to configure it, and how to use it, are
+described in its own page:
+[emacs-bacon](https://seed.pipapo.org/nodes/seed.pipapo.org/rad:zKbD2Y9kERBYScgczMaJBTRfjBhh)

--- a/website/src/config.md
+++ b/website/src/config.md
@@ -241,7 +241,10 @@ Following are 3 typical configurations.
 
 ## Locations export
 
-This is the best way to ensure you can list warnings/errors/failures and navigate between them in your IDE, for example with a plugin such as [nvim-bacon](https://github.com/Canop/nvim-bacon).
+This is the best way to ensure you can list warnings/errors/failures and navigate between them
+in your IDE, for example with a plugin such as
+[nvim-bacon](https://github.com/Canop/nvim-bacon) or
+[emacs-bacon](https://seed.pipapo.org/nodes/seed.pipapo.org/rad:zKbD2Y9kERBYScgczMaJBTRfjBhh).
 
 With the following configuration, locations are exported on each job execution.
 


### PR DESCRIPTION
added emacs-bacon to the website. Not on melpa yet, needs manual installation. I have a ticket open at melpa asking for radicle support. Ideally i want to wait that resolved rather than using a plain git receipe or mirror emacs-bacon on another forge.