### PR TITLE
make radicle id visible

### DIFF
--- a/website/src/community/emacs-bacon.md
+++ b/website/src/community/emacs-bacon.md
@@ -9,7 +9,8 @@ the current navigated item.
 
 # Development
 
-emacs-bacon is maintained [radicle](https://radicle.xyz/). Issues and PR's are maintained in
+emacs-bacon is maintained with [radicle](https://radicle.xyz/). It's radicle id is
+`rad:zKbD2Y9kERBYScgczMaJBTRfjBhh`. Issues and PR's are maintained in
 [radicle](https://radicle.xyz/guides/user#2-collaborating-the-radicle-way) as well.
 
 Discussions and feedback are welcome on mastodon. Send to `@cehteh@social.tchncs.de` with the


### PR DESCRIPTION
Doh, was a bit fast earlier. Due to the distributed nature web-frontend in radicle are rather advisory.