### PR TITLE
scroll_anchor setting

### DIFF
--- a/defaults/default-bacon.toml
+++ b/defaults/default-bacon.toml
@@ -87,6 +87,7 @@ need_stdout = true
 allow_warnings = true
 background = true
 show_command_error_code = true
+scroll_anchor = "auto"
 
 # Run your long-running application (eg server) and have the result displayed in bacon.
 # For programs that never stop (eg a server), `background` is set to false
@@ -108,6 +109,7 @@ allow_warnings = true
 background = false
 on_change_strategy = "kill_then_restart"
 # kill = ["pkill", "-TERM", "-P"]
+scroll_anchor = "auto"
 
 # This parameterized job runs the example of your choice, as soon
 # as the code compiles.

--- a/src/analysis/python/unittest.rs
+++ b/src/analysis/python/unittest.rs
@@ -67,23 +67,21 @@ pub fn build_report(cmd_lines: &[CommandOutputLine]) -> Report {
                 item_location_written = false;
             }
             LineType::Normal => {}
-            LineType::Location => {
-                if !item_location_written {
-                    if let Some(content) = cmd_line.content.if_unstyled() {
-                        // we rewrite the location as a BURP location
-                        if let Some((_, path, line)) =
-                            regex_captures!(r#"\s+File "(.+)", line (\d+)"#, content,)
-                        {
-                            items.push_line(
-                                LineType::Location,
-                                burp::location_line(format!("{path}:{line}")),
-                            );
-                            item_location_written = true;
-                        } else {
-                            warn!("inconsistent line parsing");
-                        }
-                        continue;
+            LineType::Location if !item_location_written => {
+                if let Some(content) = cmd_line.content.if_unstyled() {
+                    // we rewrite the location as a BURP location
+                    if let Some((_, path, line)) =
+                        regex_captures!(r#"\s+File "(.+)", line (\d+)"#, content,)
+                    {
+                        items.push_line(
+                            LineType::Location,
+                            burp::location_line(format!("{path}:{line}")),
+                        );
+                        item_location_written = true;
+                    } else {
+                        warn!("inconsistent line parsing");
                     }
+                    continue;
                 }
             }
             _ => {}

--- a/src/conf/config.rs
+++ b/src/conf/config.rs
@@ -60,7 +60,8 @@ pub struct Config {
     /// Whether to show diagnostics summarized instead of full
     pub summary: Option<bool>,
 
-    /// Deprecated toggle that enables a built-in set of Vim-style keybindings. Use `keybindings` instead
+    /// Deprecated toggle that enables a built-in set of Vim-style keybindings.
+    /// Use `keybindings` instead
     #[deprecated(since = "2.0.0", note = "use keybindings")]
     pub vim_keys: Option<bool>,
 

--- a/src/jobs/job.rs
+++ b/src/jobs/job.rs
@@ -128,6 +128,14 @@ pub struct Job {
     /// An optional working directory for the job command, which
     /// would override the package directory.
     pub workdir: Option<PathBuf>,
+
+    /// Where to anchor the scroll when the output changes and the user didn't scroll up manually.
+    ///
+    /// When not specified, default will be 'first', as bacon usually displays the most important
+    /// item on top. Setting it to 'auto' will make bacon use 'first' when the command errored
+    /// (eg compilation errors) and 'last' otherwise, which is useful for commands like `cargo run`
+    /// where you want to see the last output when it runs successfully.
+    pub scroll_anchor: Option<ScrollAnchor>,
 }
 
 static DEFAULT_ARGS: &[&str] = &["--color", "always"];
@@ -187,6 +195,9 @@ impl Job {
     pub fn on_change_strategy(&self) -> OnChangeStrategy {
         self.on_change_strategy
             .unwrap_or(OnChangeStrategy::WaitThenRestart)
+    }
+    pub fn scroll_anchor(&self) -> ScrollAnchor {
+        self.scroll_anchor.unwrap_or(ScrollAnchor::First)
     }
     pub fn apply(
         &mut self,
@@ -264,6 +275,9 @@ impl Job {
         if let Some(p) = job.workdir.as_ref() {
             self.workdir = Some(p.clone());
         }
+        if let Some(v) = job.scroll_anchor {
+            self.scroll_anchor = Some(v);
+        }
         self.skin.apply(job.skin);
     }
 }
@@ -307,6 +321,7 @@ fn test_job_apply() {
         },
         workdir: Some(PathBuf::from("/path/to/workdir")),
         skin: Default::default(),
+        scroll_anchor: Some(ScrollAnchor::Last),
     };
     base_job.apply(&job_to_apply);
     dbg!(&base_job);

--- a/src/tui/mission_state.rs
+++ b/src/tui/mission_state.rs
@@ -60,7 +60,11 @@ pub struct MissionState<'a, 'm> {
     /// number of lines hidden on top due to scroll
     scroll: usize,
     /// `item_idx` of the item which was on top on last draw
+    /// (but not necessarily due to volontary scroll)
     top_item_idx: usize,
+    /// `item_idx` of the item the user scrolled to, if any, which we will try to keep on top when
+    /// possible
+    scrolled_to_top_item_idx: Option<usize>,
     /// the tool building the help line
     help_line: Option<HelpLine>,
     /// the help page displayed over the rest, if any
@@ -79,6 +83,9 @@ pub struct MissionState<'a, 'm> {
     pub search: SearchState,
     /// The dialog that may be displayed over the rest of the UI
     pub dialog: Dialog,
+    /// the prefered scroll anchor, which we try to stick to when the user didn't volontarily
+    /// scroll to another item
+    pub scroll_anchor: ScrollAnchor,
 }
 
 impl<'a, 'm> MissionState<'a, 'm> {
@@ -107,6 +114,9 @@ impl<'a, 'm> MissionState<'a, 'm> {
             .help_line
             .then(|| HelpLine::new(mission.settings));
         let show_changes_count = mission.job.show_changes_count();
+        let scroll_anchor = mission.job.scroll_anchor();
+        warn!("mission settings: {:#?}", &mission.job);
+        warn!("MissionState::new - scroll_anchor: {:?}", scroll_anchor);
         Ok(Self {
             report_maker,
             output: None,
@@ -123,6 +133,7 @@ impl<'a, 'm> MissionState<'a, 'm> {
             show_changes_count,
             status_skin,
             scroll: 0,
+            scrolled_to_top_item_idx: None,
             top_item_idx: 0,
             help_line,
             help_page: None,
@@ -134,6 +145,7 @@ impl<'a, 'm> MissionState<'a, 'm> {
             dialog: Dialog::None,
             app_state,
             mission,
+            scroll_anchor,
         })
     }
     pub fn open_jobs_menu(&mut self) {
@@ -382,7 +394,7 @@ impl<'a, 'm> MissionState<'a, 'm> {
         &mut self,
         line: CommandOutputLine,
     ) {
-        let auto_scroll = self.is_scroll_at_bottom();
+        let auto_scroll = self.is_scroll_at_prefered_end();
         let line_count_before = self.lines_to_draw_unfiltered().len();
         if let Some(output) = self.output.as_mut() {
             self.report_maker.receive_line(line, output);
@@ -390,8 +402,8 @@ impl<'a, 'm> MissionState<'a, 'm> {
                 self.update_wrap();
             }
             if auto_scroll {
-                // if the user never scrolled, we'll stick to the bottom
-                self.scroll_to_bottom();
+                // if the user never scrolled, we'll stick to the prefered anchor
+                self.scroll_to_prefered_end();
             }
         } else {
             self.wrapped_output = None;
@@ -491,7 +503,7 @@ impl<'a, 'm> MissionState<'a, 'm> {
         }
 
         // we keep the scroll when the number of lines didn't change
-        let reset_scroll = self.cmd_result.lines_len() != cmd_result.lines_len();
+        let fix_scroll = self.cmd_result.lines_len() != cmd_result.lines_len();
 
         self.wrapped_report = None;
         self.wrapped_output = None;
@@ -501,15 +513,18 @@ impl<'a, 'm> MissionState<'a, 'm> {
         self.apply_filter();
 
         self.computing = false;
-        if reset_scroll {
-            self.reset_scroll();
-        }
         self.raw_output = false;
         if self.wrap {
             self.update_wrap();
         }
-
-        self.try_scroll_to_last_top_item();
+        if fix_scroll {
+            if self.scrolled_to_top_item_idx == Some(self.top_item_idx) {
+                self.show_item(self.top_item_idx);
+            } else {
+                self.scrolled_to_top_item_idx = None;
+                self.reset_scroll();
+            }
+        }
 
         // we do all exports which are set to auto
         self.mission.settings.exports.do_auto_exports(self);
@@ -556,27 +571,54 @@ impl<'a, 'm> MissionState<'a, 'm> {
         let ch = self.content_height();
         let ph = self.page_height();
         self.scroll = ch.saturating_sub(ph);
-        // we don't set top_item_idx - does it matter?
+        self.top_item_idx = self.top_item_idx().unwrap_or(0);
+    }
+    fn scroll_to_end(
+        &mut self,
+        end: ScrollEnd,
+    ) {
+        match (end, self.reverse) {
+            (ScrollEnd::First, false) => self.scroll_to_top(),
+            (ScrollEnd::First, true) => self.scroll_to_bottom(),
+            (ScrollEnd::Last, false) => self.scroll_to_bottom(),
+            (ScrollEnd::Last, true) => self.scroll_to_top(),
+        }
+    }
+    fn scroll_to_prefered_end(&mut self) {
+        let end = self.prefered_scroll_end();
+        self.scroll_to_end(end);
+    }
+    fn current_scroll_end(&self) -> Option<ScrollEnd> {
+        if self.is_scroll_at_top() {
+            Some(ScrollEnd::First)
+        } else if self.is_scroll_at_bottom() {
+            Some(ScrollEnd::Last)
+        } else {
+            None
+        }
+    }
+    fn is_scroll_at_top(&self) -> bool {
+        self.scroll == 0
     }
     fn is_scroll_at_bottom(&self) -> bool {
         self.scroll + self.page_height() + 1 >= self.content_height()
     }
-    fn reset_scroll(&mut self) {
-        if self.reverse {
-            self.scroll_to_bottom();
-        } else {
-            self.scroll_to_top();
+    fn is_scroll_at_prefered_end(&self) -> bool {
+        match (self.prefered_scroll_end(), self.reverse) {
+            (ScrollEnd::First, false) => self.is_scroll_at_top(),
+            (ScrollEnd::First, true) => self.is_scroll_at_bottom(),
+            (ScrollEnd::Last, false) => self.is_scroll_at_bottom(),
+            (ScrollEnd::Last, true) => self.is_scroll_at_top(),
         }
+    }
+    fn reset_scroll(&mut self) {
+        self.scroll_to_prefered_end();
     }
     fn fix_scroll(&mut self) {
         self.scroll = fix_scroll(self.scroll, self.content_height(), self.page_height());
     }
     pub fn keybindings(&self) -> &KeyBindings {
         &self.mission.settings.keybindings
-    }
-    fn try_scroll_to_last_top_item(&mut self) {
-        info!("try_scroll_to_last_top_item: {}", self.top_item_idx);
-        self.show_item(self.top_item_idx);
     }
     fn show_line(
         &mut self,
@@ -613,10 +655,11 @@ impl<'a, 'm> MissionState<'a, 'm> {
         };
     }
     pub fn toggle_summary_mode(&mut self) {
+        let visible_state = self.visible_scroll_state();
         self.summary ^= true;
-        self.try_scroll_to_last_top_item();
         self.search.touch();
         self.update_search();
+        self.restore_visible_scroll_state(visible_state);
         self.show_selected_found();
     }
     pub fn toggle_backtrace(
@@ -630,6 +673,7 @@ impl<'a, 'm> MissionState<'a, 'm> {
         };
     }
     pub fn toggle_wrap_mode(&mut self) {
+        let visible_state = self.visible_scroll_state();
         self.wrap ^= true;
         if self.wrapped_output.is_some() {
             self.wrapped_output = None;
@@ -637,8 +681,8 @@ impl<'a, 'm> MissionState<'a, 'm> {
         if self.wrap {
             self.update_wrap();
         }
-        self.try_scroll_to_last_top_item();
         self.search.touch();
+        self.restore_visible_scroll_state(visible_state);
     }
     fn content_height(&self) -> usize {
         let lines = self.lines_to_draw();
@@ -652,6 +696,7 @@ impl<'a, 'm> MissionState<'a, 'm> {
         width: u16,
         height: u16,
     ) {
+        let visible_state = self.visible_scroll_state();
         if self.width != width {
             self.wrapped_report = None;
             self.wrapped_output = None;
@@ -661,8 +706,24 @@ impl<'a, 'm> MissionState<'a, 'm> {
         if self.wrap {
             self.update_wrap();
         }
-        self.try_scroll_to_last_top_item();
         self.search.touch();
+        self.restore_visible_scroll_state(visible_state);
+    }
+    pub fn visible_scroll_state(&self) -> VisibleScrollState {
+        if let Some(scroll_end) = self.current_scroll_end() {
+            VisibleScrollState::ScrollEnd(scroll_end)
+        } else {
+            VisibleScrollState::TopItemIdx(self.top_item_idx)
+        }
+    }
+    pub fn restore_visible_scroll_state(
+        &mut self,
+        state: VisibleScrollState,
+    ) {
+        match state {
+            VisibleScrollState::ScrollEnd(end) => self.scroll_to_end(end),
+            VisibleScrollState::TopItemIdx(idx) => self.show_item(idx),
+        }
     }
     pub fn apply_scroll_command(
         &mut self,
@@ -671,9 +732,8 @@ impl<'a, 'm> MissionState<'a, 'm> {
         if let Some(help_page) = self.help_page.as_mut() {
             help_page.apply_scroll_command(cmd);
         } else {
-            debug!("content_height: {}", self.content_height());
-            debug!("page_height: {}", self.page_height());
             self.scroll = cmd.apply(self.scroll, self.content_height(), self.page_height());
+            self.scrolled_to_top_item_idx = self.top_item_idx();
         }
     }
     /// draw the grey line containing the keybindings indications
@@ -877,6 +937,19 @@ impl<'a, 'm> MissionState<'a, 'm> {
             CommandResult::Report(report) => !self.mission.is_success(report),
             CommandResult::Failure(_) => true,
             CommandResult::None => false,
+        }
+    }
+    pub fn prefered_scroll_end(&self) -> ScrollEnd {
+        match self.scroll_anchor {
+            ScrollAnchor::Auto => {
+                if self.is_failure() {
+                    ScrollEnd::First
+                } else {
+                    ScrollEnd::Last
+                }
+            }
+            ScrollAnchor::First => ScrollEnd::First,
+            ScrollAnchor::Last => ScrollEnd::Last,
         }
     }
     /// Return the (unfiltered) set of lines to draw, depending on whether we wrap or not

--- a/src/tui/mission_state.rs
+++ b/src/tui/mission_state.rs
@@ -115,8 +115,6 @@ impl<'a, 'm> MissionState<'a, 'm> {
             .then(|| HelpLine::new(mission.settings));
         let show_changes_count = mission.job.show_changes_count();
         let scroll_anchor = mission.job.scroll_anchor();
-        warn!("mission settings: {:#?}", &mission.job);
-        warn!("MissionState::new - scroll_anchor: {:?}", scroll_anchor);
         Ok(Self {
             report_maker,
             output: None,

--- a/src/tui/scroll/mod.rs
+++ b/src/tui/scroll/mod.rs
@@ -1,0 +1,50 @@
+mod scroll_anchor;
+mod scroll_command;
+
+pub use {
+    scroll_anchor::*,
+    scroll_command::ScrollCommand,
+};
+
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScrollEnd {
+    First,
+    Last,
+}
+
+pub enum VisibleScrollState {
+    ScrollEnd(ScrollEnd),
+    TopItemIdx(usize),
+}
+
+impl ScrollEnd {
+    pub fn reverse(self) -> Self {
+        match self {
+            ScrollEnd::First => ScrollEnd::Last,
+            ScrollEnd::Last => ScrollEnd::First,
+        }
+    }
+}
+
+pub fn is_thumb(
+    y: usize,
+    scrollbar: Option<(u16, u16)>,
+) -> bool {
+    scrollbar.is_some_and(|(sctop, scbottom)| {
+        let y = y as u16;
+        sctop <= y && y <= scbottom
+    })
+}
+
+pub fn fix_scroll(
+    scroll: usize,
+    content_height: usize,
+    page_height: usize,
+) -> usize {
+    if content_height > page_height {
+        scroll.min(content_height - page_height)
+    } else {
+        0
+    }
+}

--- a/src/tui/scroll/scroll_anchor.rs
+++ b/src/tui/scroll/scroll_anchor.rs
@@ -1,0 +1,89 @@
+use {
+    schemars::{
+        JsonSchema,
+        Schema,
+        SchemaGenerator,
+        json_schema,
+    },
+    serde::{
+        Deserialize,
+        Deserializer,
+        Serialize,
+        Serializer,
+        de,
+    },
+    std::{
+        borrow::Cow,
+        fmt,
+        str::FromStr,
+    },
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScrollAnchor {
+    Auto, // not the same as a None: it can override a None
+    First,
+    Last,
+}
+
+impl fmt::Display for ScrollAnchor {
+    fn fmt(
+        &self,
+        f: &mut fmt::Formatter<'_>,
+    ) -> fmt::Result {
+        match self {
+            ScrollAnchor::Auto => write!(f, "auto"),
+            ScrollAnchor::First => write!(f, "first"),
+            ScrollAnchor::Last => write!(f, "last"),
+        }
+    }
+}
+
+impl FromStr for ScrollAnchor {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "auto" => Ok(ScrollAnchor::Auto),
+            "first" => Ok(ScrollAnchor::First),
+            "last" => Ok(ScrollAnchor::Last),
+            _ => Err(format!("invalid scroll anchor: {}", s)),
+        }
+    }
+}
+impl Serialize for ScrollAnchor {
+    fn serialize<S>(
+        &self,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.collect_str(self)
+    }
+}
+impl<'de> Deserialize<'de> for ScrollAnchor {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        FromStr::from_str(&s).map_err(de::Error::custom)
+    }
+}
+
+impl JsonSchema for ScrollAnchor {
+    fn schema_name() -> Cow<'static, str> {
+        "ScrollAnchor".into()
+    }
+    fn schema_id() -> Cow<'static, str> {
+        concat!(module_path!(), "::ScrollAnchor").into()
+    }
+    fn json_schema(_gen: &mut SchemaGenerator) -> Schema {
+        json_schema!({
+            "type": "string",
+        })
+    }
+    fn inline_schema() -> bool {
+        true
+    }
+}

--- a/src/tui/scroll/scroll_command.rs
+++ b/src/tui/scroll/scroll_command.rs
@@ -166,28 +166,6 @@ impl<'de> Deserialize<'de> for ScrollCommand {
     }
 }
 
-pub fn is_thumb(
-    y: usize,
-    scrollbar: Option<(u16, u16)>,
-) -> bool {
-    scrollbar.is_some_and(|(sctop, scbottom)| {
-        let y = y as u16;
-        sctop <= y && y <= scbottom
-    })
-}
-
-pub fn fix_scroll(
-    scroll: usize,
-    content_height: usize,
-    page_height: usize,
-) -> usize {
-    if content_height > page_height {
-        scroll.min(content_height - page_height - 1)
-    } else {
-        0
-    }
-}
-
 #[test]
 fn test_scroll_command_string_round_trip() {
     let commands = [

--- a/website/src/config.md
+++ b/website/src/config.md
@@ -91,6 +91,7 @@ need_stdout |whether we need to capture stdout too (stderr is always captured) |
 on_change_strategy | `wait_then_restart` or `kill_then_restart` |
 on_success | the action to run when there's no error, warning or test failures |
 show_command_error_code | if true, show any non zero status as badge (makes sense for eg `bacon run`) |
+scroll_anchor | `first`, `last`, or `auto` : see [below](#scroll-anchor) | `first`
 skin | bacon application colors, [see below](#skin) |
 watch | a list of files and directories that will be watched if the job is run on a package. Usual source directories are implicitly included unless `default_watch` is set to false |
 workdir | overrides the execution directory |
@@ -323,6 +324,24 @@ ctrl-e = "export:json-report"
 
 Have a look, at least once, at the default configuration files.
 They contain many other properties, commented out, that you may find useful.
+
+## Scroll Anchor
+
+By default, bacon sorts items, with errors first, followed by warnings.
+
+The first items (on top if you don't have the *reverse* setting) are usually the most interesting ones.
+
+But not always. For example, with the `run` job, when there's no error and the compiled binary is effectively executed, you may want to focus on the output of the program.
+And if it's a `long run`, you probably want to have the scroll follow the new lines unless you decided to scroll away.
+
+This is achieved with the `scroll_anchor` setting, whose value can be undefined, `auto`, `first`, or `last`.
+
+When not defined, the applied default is `first`.
+
+In the default `bacon.toml`, the `run` and `run-long` jobs have `scroll_anchor = "auto"` which means that:
+
+* if errors were recorded, the default sticky position is the first item
+* if there was no error, the default stiky item is the last one (bacon then acting as `tail` to follow new lines)
 
 ## listen
 


### PR DESCRIPTION
bacon sorts items, with errors first, followed by warnings.

The first items (on top if you don't have the *reverse* setting) are usually the most interesting ones.

But not always. For example, with the `run` job, when there's no error and the compiled binary is effectively executed, you may want to focus on the output of the program.
And if it's a `long run`, you probably want to have the scroll follow the new lines unless you decided to scroll away.

This PR introduces the `scroll_anchor` setting, whose value can be undefined, `auto`, `first`, or `last`.

When not defined, the applied default will be `first`.

In the default `bacon.toml`, the `run` and `run-long` jobs have `scroll_anchor = "auto"` which means that:

* if errors were recorded, the default sticky position is the first item
* if there was no error, the default stiky item is the last one (bacon then acting as `tail` to follow new lines)

This should fix #384 but there will be a test period before I try to merge it, or not. Feedback welcome.