### PR TITLE
Use the level provided in json for cargo_json analyzer

### DIFF
--- a/src/analysis/cargo_json/mod.rs
+++ b/src/analysis/cargo_json/mod.rs
@@ -3,14 +3,18 @@ mod cargo_json_export;
 use {
     super::*,
     crate::{
-        analysis::standard,
+        analysis::standard::build_report_from_analysis,
         *,
     },
     anyhow::Result,
+    lazy_regex::*,
     cargo_json_export::*,
     cargo_metadata::{
         Message,
-        diagnostic::Diagnostic,
+        diagnostic::{
+            Diagnostic,
+            DiagnosticLevel,
+        },
     },
 };
 
@@ -26,7 +30,7 @@ use {
 /// not sure this is worth it.
 #[derive(Default)]
 pub struct CargoJsonAnalyzer {
-    lines: Vec<CommandOutputLine>,
+    analysis: Vec<(LineAnalysis, TLine)>,
     exports: Vec<CargoJsonExport>,
 }
 
@@ -35,7 +39,7 @@ impl Analyzer for CargoJsonAnalyzer {
         &mut self,
         mission: &Mission,
     ) {
-        self.lines.clear();
+        self.analysis.clear();
         self.exports.clear();
         for (name, export_settings) in &mission.settings.exports.exports {
             if export_settings.exporter == Exporter::Analyser {
@@ -69,8 +73,7 @@ impl Analyzer for CargoJsonAnalyzer {
     }
 
     fn build_report(&mut self) -> Result<Report> {
-        let line_analyzer = standard::StandardLineAnalyzer {};
-        let mut report = standard::build_report(&self.lines, line_analyzer);
+        let mut report = build_report_from_analysis(self.analysis.drain(..));
         for export in self.exports.drain(..) {
             report.analyzer_exports.insert(export.name, export.export);
         }
@@ -106,7 +109,7 @@ impl CargoJsonAnalyzer {
         let Diagnostic {
             //message,
             //code,
-            //level,
+            level,
             //spans,
             children,
             //suggestion,
@@ -114,11 +117,23 @@ impl CargoJsonAnalyzer {
             ..
         } = diagnostic;
         if let Some(rendered) = rendered {
+            let mut line_type = match level {
+                DiagnosticLevel::Error | DiagnosticLevel::Ice => LineType::Title(Kind::Error),
+                DiagnosticLevel::Warning => LineType::Title(Kind::Warning),
+                _ => LineType::Normal,
+            };
             for line in rendered.trim().lines() {
                 let content = TLine::from_tty(line);
-                let cmd_line = CommandOutputLine { content, origin };
-                command_output.push(cmd_line.clone());
-                self.lines.push(cmd_line);
+                command_output.push(CommandOutputLine { content: content.clone(), origin });
+                if line_type == LineType::Normal {
+                    let raw = content.to_raw();
+                    if regex_is_match!(r":\d+:\d+", &raw)
+                    {
+                        line_type = LineType::Location;
+                    }
+                }
+                self.analysis.push((LineAnalysis::of_type(line_type), content));
+                line_type = LineType::Normal;
             }
         }
         for child in children {

--- a/src/analysis/standard/mod.rs
+++ b/src/analysis/standard/mod.rs
@@ -4,6 +4,7 @@ mod standard_report_building;
 pub use {
     standard_line_analyser::StandardLineAnalyzer,
     standard_report_building::build_report,
+    standard_report_building::build_report_from_analysis,
 };
 
 use {

--- a/src/analysis/standard/standard_report_building.rs
+++ b/src/analysis/standard/standard_report_building.rs
@@ -7,6 +7,14 @@ pub fn build_report<L: LineAnalyzer>(
     cmd_lines: &[CommandOutputLine],
     mut line_analyzer: L,
 ) -> Report {
+    build_report_from_analysis(
+        cmd_lines
+            .iter()
+            .map(|line| (line_analyzer.analyze_line(line), line.content.clone())),
+    )
+}
+
+pub fn build_report_from_analysis(lines: impl Iterator<Item = (LineAnalysis, TLine)>) -> Report {
     #[derive(Debug, Default)]
     struct Test {
         passed: bool,
@@ -21,13 +29,12 @@ pub fn build_report<L: LineAnalyzer>(
     let mut cur_err_kind = None; // the current kind among stderr lines
     let mut is_in_out_fail = false;
     let mut suggest_backtrace = false;
-    for cmd_line in cmd_lines {
-        let line_analysis = line_analyzer.analyze_line(cmd_line);
+    for (line_analysis, content) in lines {
         let line_type = line_analysis.line_type;
         let mut line = Line {
             item_idx: 0, // will be filled later
             line_type,
-            content: cmd_line.content.clone(),
+            content,
         };
         match (line_type, line_analysis.key) {
             (LineType::TestResult(r), Some(key)) => {


### PR DESCRIPTION
Hi! First, thanks for the bacon, it is a very nice tool.

I'm working on a [new language CO2](https://github.com/hkalbasi/co2) which is basically C with some Rust interop features. It uses a cargo wrapper `co2cargo` which tries to be highly compatible with cargo.

I tried to use bacon with `co2cargo`, and it failed, because I use a slightly different formatting for diagnostics. I found out that bacon has a `cargo_json` format analyzer, and `co2cargo` supports cargo's json format. Problem solved, right?

It turns out that `cargo_json` is not very different from the text based analyzer, and just run the text based analyzer on the `rendered` field of the json. So it didn't help in my case, and I decided to make this PR to address that.

This PR slightly improves the situation, by obtaining the level of the diagnostic from the json `level` field, not parsing it from the `rendered` field. This makes `cargo_json` format more robust from future changes in the text format, and enables third party tools (like `co2cargo`) who emit diagnostics compatible with `cargo_json` but not using the same text format to be usable with bacon.

IIUC, current bacon design is hostile to structured formats, and they are second class compared to text based parsers. Which is sad because text based formats are not stable in most tools, and will eventually break, specially now that bacon is expanding its analyzers to support more tools from more language. Part of the problem is that bacon does its ui elements on top of the text emitted by the tool, but I still think there is room for improvements on structured formats handling.