### PR TITLE
Add a clear-output action

### DIFF
--- a/defaults/default-prefs.toml
+++ b/defaults/default-prefs.toml
@@ -117,4 +117,4 @@ base_volume = "100%" # global volume multiplier
 # t = "job:test"
 # r = "job:run"
 # ctrl-e = "export:analysis"
-
+# x = "clear-output"

--- a/src/analysis/cargo_json/mod.rs
+++ b/src/analysis/cargo_json/mod.rs
@@ -7,7 +7,6 @@ use {
         *,
     },
     anyhow::Result,
-    lazy_regex::*,
     cargo_json_export::*,
     cargo_metadata::{
         Message,
@@ -16,6 +15,7 @@ use {
             DiagnosticLevel,
         },
     },
+    lazy_regex::*,
 };
 
 /// An analyzer able to read the output
@@ -124,15 +124,18 @@ impl CargoJsonAnalyzer {
             };
             for line in rendered.trim().lines() {
                 let content = TLine::from_tty(line);
-                command_output.push(CommandOutputLine { content: content.clone(), origin });
+                command_output.push(CommandOutputLine {
+                    content: content.clone(),
+                    origin,
+                });
                 if line_type == LineType::Normal {
                     let raw = content.to_raw();
-                    if regex_is_match!(r":\d+:\d+", &raw)
-                    {
+                    if regex_is_match!(r":\d+:\d+", &raw) {
                         line_type = LineType::Location;
                     }
                 }
-                self.analysis.push((LineAnalysis::of_type(line_type), content));
+                self.analysis
+                    .push((LineAnalysis::of_type(line_type), content));
                 line_type = LineType::Normal;
             }
         }

--- a/src/analysis/standard/mod.rs
+++ b/src/analysis/standard/mod.rs
@@ -3,8 +3,10 @@ mod standard_report_building;
 
 pub use {
     standard_line_analyser::StandardLineAnalyzer,
-    standard_report_building::build_report,
-    standard_report_building::build_report_from_analysis,
+    standard_report_building::{
+        build_report,
+        build_report_from_analysis,
+    },
 };
 
 use {

--- a/src/conf/action.rs
+++ b/src/conf/action.rs
@@ -27,7 +27,7 @@ use {
 pub enum Action {
     Back,       // leave help, clear search, go to previous job, leave, etc.
     BackOrQuit, // same as Back but quits if there is nothing to go back to
-    Clear,
+    ClearOutput,
     CopyUnstyledOutput,
     DismissTop,
     DismissTopItem,
@@ -73,7 +73,7 @@ impl Md for Action {
             Self::BackOrQuit => {
                 "back to previous page or job, quitting if there is none".to_string()
             }
-            Self::Clear => "clear output".to_string(),
+            Self::ClearOutput => "clear output".to_string(),
             Self::CopyUnstyledOutput => "copy unstyled output".to_string(),
             Self::DismissTop => "dismiss top".to_string(),
             Self::DismissTopItem => "dismiss top item".to_string(),
@@ -169,7 +169,7 @@ impl fmt::Display for Action {
         match self {
             Self::Back => write!(f, "back"),
             Self::BackOrQuit => write!(f, "back-or-quit"),
-            Self::Clear => write!(f, "clear"),
+            Self::ClearOutput => write!(f, "clear output"),
             Self::CopyUnstyledOutput => write!(f, "copy-unstyled-output"),
             Self::DismissTop => write!(f, "dismiss-top"),
             Self::DismissTopItem => write!(f, "dismiss-top-item"),
@@ -239,7 +239,7 @@ impl FromStr for Action {
             r"^job:(?<job_ref>.+)$" => Self::Job(job_ref.into()),
             r"^(?:internal:)?back$" => Self::Back,
             r"^(?:internal:)?back-or-quit$" => Self::BackOrQuit,
-            r"^(?:internal:)?clear$" => Self::Clear,
+            r"^(?:internal:)?clear-output$" => Self::ClearOutput,
             r"^(?:internal:)?dismiss-top$" => Self::DismissTop,
             r"^(?:internal:)?dismiss-top-item$" => Self::DismissTopItem,
             r"^(?:internal:)?dismiss-top-item-type$" => Self::DismissTopItemType,
@@ -414,7 +414,7 @@ fn test_action_string_round_trip() {
         Action::Export("my export".to_string()),
         Action::Back,
         Action::BackOrQuit,
-        Action::Clear,
+        Action::ClearOutput,
         Action::DismissTop,
         Action::DismissTopItem,
         Action::DismissTopItemType,

--- a/src/conf/action.rs
+++ b/src/conf/action.rs
@@ -27,6 +27,7 @@ use {
 pub enum Action {
     Back,       // leave help, clear search, go to previous job, leave, etc.
     BackOrQuit, // same as Back but quits if there is nothing to go back to
+    Clear,
     CopyUnstyledOutput,
     DismissTop,
     DismissTopItem,
@@ -72,7 +73,8 @@ impl Md for Action {
             Self::BackOrQuit => {
                 "back to previous page or job, quitting if there is none".to_string()
             }
-            Self::CopyUnstyledOutput => "copy current job's output".to_string(),
+            Self::Clear => "clear output".to_string(),
+            Self::CopyUnstyledOutput => "copy unstyled output".to_string(),
             Self::DismissTop => "dismiss top".to_string(),
             Self::DismissTopItem => "dismiss top item".to_string(),
             Self::DismissTopItemType => "dismiss top item type".to_string(),
@@ -167,6 +169,7 @@ impl fmt::Display for Action {
         match self {
             Self::Back => write!(f, "back"),
             Self::BackOrQuit => write!(f, "back-or-quit"),
+            Self::Clear => write!(f, "clear"),
             Self::CopyUnstyledOutput => write!(f, "copy-unstyled-output"),
             Self::DismissTop => write!(f, "dismiss-top"),
             Self::DismissTopItem => write!(f, "dismiss-top-item"),
@@ -236,6 +239,7 @@ impl FromStr for Action {
             r"^job:(?<job_ref>.+)$" => Self::Job(job_ref.into()),
             r"^(?:internal:)?back$" => Self::Back,
             r"^(?:internal:)?back-or-quit$" => Self::BackOrQuit,
+            r"^(?:internal:)?clear$" => Self::Clear,
             r"^(?:internal:)?dismiss-top$" => Self::DismissTop,
             r"^(?:internal:)?dismiss-top-item$" => Self::DismissTopItem,
             r"^(?:internal:)?dismiss-top-item-type$" => Self::DismissTopItemType,
@@ -410,6 +414,7 @@ fn test_action_string_round_trip() {
         Action::Export("my export".to_string()),
         Action::Back,
         Action::BackOrQuit,
+        Action::Clear,
         Action::DismissTop,
         Action::DismissTopItem,
         Action::DismissTopItemType,

--- a/src/result/command_output.rs
+++ b/src/result/command_output.rs
@@ -62,6 +62,9 @@ impl CommandOutput {
     pub fn len(&self) -> usize {
         self.lines.len()
     }
+    pub fn clear(&mut self) {
+        self.lines.clear();
+    }
 }
 
 impl From<RawCommandOutputLine> for CommandOutputLine {

--- a/src/result/command_result.rs
+++ b/src/result/command_result.rs
@@ -48,6 +48,14 @@ impl CommandResult {
         Ok(Self::Report(report))
     }
 
+    pub fn clear(&mut self) {
+        match self {
+            Self::Report(report) => report.clear_output(),
+            Self::Failure(failure) => failure.clear_output(),
+            Self::None => {}
+        }
+    }
+
     pub fn output(&self) -> Option<&CommandOutput> {
         match self {
             Self::Report(report) => Some(&report.output),

--- a/src/result/failure.rs
+++ b/src/result/failure.rs
@@ -13,3 +13,9 @@ pub struct Failure {
     pub output: CommandOutput,
     pub suggest_backtrace: bool,
 }
+
+impl Failure {
+    pub fn clear_output(&mut self) {
+        self.output.clear();
+    }
+}

--- a/src/result/report.rs
+++ b/src/result/report.rs
@@ -19,16 +19,16 @@ use {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Report {
     pub error_code: Option<i32>,
+    /// The output of the command, as received, and available for display of raw output
     pub output: CommandOutput,
+    /// The analyzed lines, not necessarily the whole output
     pub lines: Vec<Line>,
     pub stats: Stats,
     pub suggest_backtrace: bool,
     pub failure_keys: Vec<String>,
     /// the exports that the analyzers have done, by name
     pub analyzer_exports: HashMap<String, String>,
-
     pub has_passed_tests: bool,
-
     pub dismissed_items: usize,
     pub dismissed_lines: Vec<Line>,
 }
@@ -48,6 +48,13 @@ impl Report {
             dismissed_items: 0,
             dismissed_lines: Vec::new(),
         }
+    }
+
+    pub fn clear_output(&mut self) {
+        self.output.clear();
+        self.lines.clear();
+        self.dismissed_items = 0;
+        self.dismissed_lines.clear();
     }
 
     pub fn lines_changed(&mut self) {

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -296,8 +296,9 @@ fn run_mission(
                         mission_end = Some(DoAfterMission::NextJob(JobRef::PreviousOrQuit));
                     }
                 }
-                Action::Clear => {
-                    // FIXME
+                Action::ClearOutput => {
+                    info!("clearing output");
+                    mission_state.clear_output();
                 }
                 Action::CopyUnstyledOutput => {
                     mission_state.copy_unstyled_output();

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -296,6 +296,9 @@ fn run_mission(
                         mission_end = Some(DoAfterMission::NextJob(JobRef::PreviousOrQuit));
                     }
                 }
+                Action::Clear => {
+                    // FIXME
+                }
                 Action::CopyUnstyledOutput => {
                     mission_state.copy_unstyled_output();
                 }

--- a/src/tui/mission_state.rs
+++ b/src/tui/mission_state.rs
@@ -173,6 +173,18 @@ impl<'a, 'm> MissionState<'a, 'm> {
             self.reset_scroll();
         }
     }
+    pub fn clear_output(&mut self) {
+        if let Some(output) = self.output.as_mut() {
+            output.clear();
+        }
+        self.cmd_result.clear();
+        self.wrapped_report = None;
+        self.wrapped_output = None;
+        if self.wrap {
+            self.update_wrap();
+        }
+        self.reset_scroll();
+    }
     /// Show a specific diagnostic item by index and scroll to show it
     ///
     /// Do nothing if there's no such item
@@ -993,10 +1005,12 @@ impl<'a, 'm> MissionState<'a, 'm> {
     fn update_wrap(&mut self) {
         let width = self.width - 1;
         if let Some(report) = self.report_to_draw() {
+            info!("wrap source: report");
             if self.wrapped_report.is_none() {
                 self.wrapped_report = Some(WrappedReport::new(report, width));
             }
         } else if let Some(output) = self.cmd_result.output().or(self.output.as_ref()) {
+            info!("wrap source: output");
             match self.wrapped_output.as_mut() {
                 None => {
                     let old_len = self.wrapped_output.as_ref().map(|wo| wo.sub_lines.len());


### PR DESCRIPTION
This can be tested by adding a key binding such as

`x = "clear-output"`

Fix #419