### PR TITLE
Support specifying any rgb color in `skin`

### DIFF
--- a/src/conf/skin.rs
+++ b/src/conf/skin.rs
@@ -1,14 +1,36 @@
-use {
-    paste::paste,
-    schemars::JsonSchema,
-    serde::Deserialize,
-    termimad::crossterm::style::Color,
-};
+use {paste::paste, schemars::JsonSchema, serde::Deserialize, termimad::crossterm::style::Color};
+
+#[derive(Debug, Copy, Clone, Deserialize, PartialEq, JsonSchema)]
+#[serde(untagged)]
+pub enum ConfigColor {
+    Ansi(u8),
+    Rgb { r: u8, g: u8, b: u8 },
+}
+
+pub trait DisplayColor {
+    fn display_fg(&self) -> String;
+    fn display_bg(&self) -> String;
+}
+
+impl DisplayColor for ConfigColor {
+    fn display_fg(&self) -> String {
+        match self {
+            Self::Ansi(color_index) => format!("\u{1b}[38;5;{color_index}m"),
+            Self::Rgb { r, g, b } => format!("\u{1b}[38;2;{r};{g};{b}m"),
+        }
+    }
+    fn display_bg(&self) -> String {
+        match self {
+            Self::Ansi(color_index) => format!("\u{1b}[48;5;{color_index}m"),
+            Self::Rgb { r, g, b } => format!("\u{1b}[48;2;{r};{g};{b}m"),
+        }
+    }
+}
 
 /// Define a `BaconSkin` struct with fields being u8 with default values.
 macro_rules! BaconSkin {
     (
-        $( $(#[$meta:meta])* $name:ident: $default:literal, )*
+        $( $(#[$meta:meta])* $name:ident: $default:expr, )*
     ) => {
         paste! {
             $(
@@ -17,12 +39,12 @@ macro_rules! BaconSkin {
                 #[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq, JsonSchema)]
                 #[serde(untagged)]
                 pub enum [<Defaulting$name:camel>] {
-                    Set(u8),
+                    Set(ConfigColor),
                     #[default]
                     Unset,
                 }
                 impl [<Defaulting$name:camel>] {
-                    pub fn value(self) -> u8 {
+                    pub fn value(self) -> ConfigColor {
                         match self {
                             Self::Set(value) => value,
                             Self::Unset => $default,
@@ -34,7 +56,10 @@ macro_rules! BaconSkin {
                         }
                     }
                     pub fn color(self) -> Color {
-                        Color::AnsiValue(self.value())
+                        match self.value() {
+                            ConfigColor::Ansi(color_index) => Color::AnsiValue(color_index),
+                            ConfigColor::Rgb { r, g, b } => Color::Rgb { r, g, b }
+                        }
                     }
                 }
             )*
@@ -55,7 +80,7 @@ macro_rules! BaconSkin {
                 }
                 $(
                     #[inline]
-                    pub fn [<$name>](&self) -> u8 {
+                    pub fn [<$name>](&self) -> ConfigColor {
                         self.$name.value()
                     }
                 )*
@@ -67,73 +92,73 @@ macro_rules! BaconSkin {
 // The colors of Bacon, with default values (ANSI color codes, in 0-255)
 BaconSkin! {
     /// Foreground color of the status line
-    status_fg: 252,
+    status_fg: ConfigColor::Ansi(252),
     /// Background color of the status line
-    status_bg: 239,
+    status_bg: ConfigColor::Ansi(239),
     /// Foreground color used for key shortcuts in the UI
-    key_fg: 204,
+    key_fg: ConfigColor::Ansi(204),
     /// Foreground color for key shortcuts displayed in the status line
-    status_key_fg: 204,
+    status_key_fg: ConfigColor::Ansi(204),
     /// Foreground color of the project name badge
-    project_name_badge_fg: 255,
+    project_name_badge_fg: ConfigColor::Ansi(255),
     /// Background color of the project name badge
-    project_name_badge_bg: 240,
+    project_name_badge_bg: ConfigColor::Ansi(240),
     /// Foreground color of the job label badge
-    job_label_badge_fg: 235,
+    job_label_badge_fg: ConfigColor::Ansi(235),
     /// Background color of the job label badge
-    job_label_badge_bg: 204,
+    job_label_badge_bg: ConfigColor::Ansi(204),
     /// Foreground color of the errors badge
-    errors_badge_fg: 235,
+    errors_badge_fg: ConfigColor::Ansi(235),
     /// Background color of the errors badge
-    errors_badge_bg: 9,
+    errors_badge_bg: ConfigColor::Ansi(9),
     /// Foreground color of the failing-tests badge
-    test_fails_badge_fg: 235,
+    test_fails_badge_fg: ConfigColor::Ansi(235),
     /// Background color of the failing-tests badge
-    test_fails_badge_bg: 208,
+    test_fails_badge_bg: ConfigColor::Ansi(208),
     /// Foreground color of the passing-tests badge
-    test_pass_badge_fg: 254,
+    test_pass_badge_fg: ConfigColor::Ansi(254),
     /// Background color of the passing-tests badge
-    test_pass_badge_bg: 2,
+    test_pass_badge_bg: ConfigColor::Ansi(2),
     /// Foreground color of the warnings badge
-    warnings_badge_fg: 235,
+    warnings_badge_fg: ConfigColor::Ansi(235),
     /// Background color of the warnings badge
-    warnings_badge_bg: 11,
+    warnings_badge_bg: ConfigColor::Ansi(11),
     /// Foreground color of the command-error badge
-    command_error_badge_fg: 235,
+    command_error_badge_fg: ConfigColor::Ansi(235),
     /// Background color of the command-error badge
-    command_error_badge_bg: 9,
+    command_error_badge_bg: ConfigColor::Ansi(9),
     /// Foreground color of the dismissed badge
-    dismissed_badge_fg: 235,
+    dismissed_badge_fg: ConfigColor::Ansi(235),
     /// Background color of the dismissed badge
-    dismissed_badge_bg: 6,
+    dismissed_badge_bg: ConfigColor::Ansi(6),
     /// Foreground color of the change badge
-    change_badge_fg: 235,
+    change_badge_fg: ConfigColor::Ansi(235),
     /// Background color of the change badge
-    change_badge_bg: 6,
+    change_badge_bg: ConfigColor::Ansi(6),
     /// Foreground color of the "computing..." indicator
-    computing_fg: 235,
+    computing_fg: ConfigColor::Ansi(235),
     /// Background color of the "computing..." indicator
-    computing_bg: 204,
+    computing_bg: ConfigColor::Ansi(204),
     /// Foreground color of search matches
-    found_fg: 208,
+    found_fg: ConfigColor::Ansi(208),
     /// Background color of the selected search match
-    found_selected_bg: 208,
+    found_selected_bg: ConfigColor::Ansi(208),
     /// Foreground color of the '/' search prefix
-    search_input_prefix_fg: 208,
+    search_input_prefix_fg: ConfigColor::Ansi(208),
     /// Foreground color of the search summary
-    search_summary_fg: 208,
+    search_summary_fg: ConfigColor::Ansi(208),
     /// Border color used for menus
-    menu_border: 234,
+    menu_border: ConfigColor::Ansi(234),
     /// Background color used for menus
-    menu_bg: 235,
+    menu_bg: ConfigColor::Ansi(235),
     /// Background color of individual menu items
-    menu_item_bg: 235,
+    menu_item_bg: ConfigColor::Ansi(235),
     /// Background color of the selected menu item
-    menu_item_selected_bg: 239,
+    menu_item_selected_bg: ConfigColor::Ansi(239),
     /// Foreground color of menu items
-    menu_item_fg: 250,
+    menu_item_fg: ConfigColor::Ansi(250),
     /// Foreground color of the selected menu item
-    menu_item_selected_fg: 255,
+    menu_item_selected_fg: ConfigColor::Ansi(255),
 }
 
 #[test]
@@ -144,18 +169,18 @@ fn test_bacon_skin_defaults() {
         project_name_badge_fg = 0
     ";
     let mut a = toml::from_str::<BaconSkin>(a).unwrap();
-    assert_eq!(a.status_fg(), 255);
-    assert_eq!(a.status_bg(), 239);
+    assert_eq!(a.status_fg(), ConfigColor::Ansi(255));
+    assert_eq!(a.status_bg(), ConfigColor::Ansi(239));
     let b = r"
         status_key_fg = 206
         status_bg = 100
     ";
     let b = toml::from_str::<BaconSkin>(b).unwrap();
     a.apply(b);
-    assert_eq!(a.status_fg(), 255);
-    assert_eq!(a.status_bg(), 100);
-    assert_eq!(a.key_fg(), 204);
-    assert_eq!(a.status_key_fg(), 206);
-    assert_eq!(a.project_name_badge_fg(), 0);
-    assert_eq!(a.project_name_badge_bg(), 240);
+    assert_eq!(a.status_fg(), ConfigColor::Ansi(255));
+    assert_eq!(a.status_bg(), ConfigColor::Ansi(100));
+    assert_eq!(a.key_fg(), ConfigColor::Ansi(204));
+    assert_eq!(a.status_key_fg(), ConfigColor::Ansi(206));
+    assert_eq!(a.project_name_badge_fg(), ConfigColor::Ansi(0));
+    assert_eq!(a.project_name_badge_bg(), ConfigColor::Ansi(240));
 }

--- a/src/tty/mod.rs
+++ b/src/tty/mod.rs
@@ -37,18 +37,12 @@ pub const CSI_BOLD_WHITE: &str = "\u{1b}[1m\u{1b}[38;5;15m";
 
 static TAB_REPLACEMENT: &str = "    ";
 
-use {
-    crate::W,
-    anyhow::Result,
-    std::io::Write,
-};
+use crate::ConfigColor;
+use crate::DisplayColor;
 
-pub use {
-    tline::*,
-    tline_builder::*,
-    trange::*,
-    tstring::*,
-};
+use {crate::W, anyhow::Result, std::io::Write};
+
+pub use {tline::*, tline_builder::*, trange::*, tstring::*};
 
 pub fn draw(
     w: &mut W,
@@ -63,8 +57,8 @@ pub fn draw(
     Ok(())
 }
 pub fn csi(
-    fg: u8,
-    bg: u8,
+    fg: ConfigColor,
+    bg: ConfigColor,
 ) -> String {
-    format!("\u{1b}[1m\u{1b}[38;5;{fg}m\u{1b}[48;5;{bg}m")
+    format!("\u{1b}[1m{}{}", fg.display_fg(), bg.display_bg())
 }

--- a/src/tty/tstring.rs
+++ b/src/tty/tstring.rs
@@ -2,14 +2,8 @@ use {
     super::*,
     crate::*,
     anyhow::*,
-    serde::{
-        Deserialize,
-        Serialize,
-    },
-    std::{
-        fmt::Write as _,
-        io::Write,
-    },
+    serde::{Deserialize, Serialize},
+    std::{fmt::Write as _, io::Write},
     termimad::StrFit,
 };
 
@@ -42,8 +36,8 @@ impl TString {
     /// colors are 8bits ansi values
     pub fn badge(
         con: &str,
-        fg: u8,
-        bg: u8,
+        fg: ConfigColor,
+        bg: ConfigColor,
     ) -> Self {
         Self {
             csi: csi(fg, bg),
@@ -53,8 +47,8 @@ impl TString {
     pub fn num_badge(
         num: usize,
         cat: &str,
-        fg: u8,
-        bg: u8,
+        fg: ConfigColor,
+        bg: ConfigColor,
     ) -> Self {
         let raw = if num < 2 {
             format!(" {num} {cat} ")

--- a/src/tui/mission_state.rs
+++ b/src/tui/mission_state.rs
@@ -2,27 +2,14 @@ use {
     crate::*,
     anyhow::Result,
     crokey::KeyCombination,
-    std::{
-        io::Write,
-        process::ExitStatus,
-        time::Instant,
-    },
+    std::{io::Write, process::ExitStatus, time::Instant},
     termimad::{
-        Area,
-        CompoundStyle,
-        MadSkin,
+        Area, CompoundStyle, MadSkin,
         crossterm::{
-            cursor,
-            execute,
-            style::{
-                Attribute,
-                Print,
-            },
+            cursor, execute,
+            style::{Attribute, Print},
         },
-        minimad::{
-            Alignment,
-            Composite,
-        },
+        minimad::{Alignment, Composite},
     },
 };
 
@@ -760,7 +747,7 @@ impl<'a, 'm> MissionState<'a, 'm> {
             if search_width > 1 {
                 // draw_prefixed_input requires a width > 1
                 let skin = self.mission.job.skin;
-                let csi = format!("\u{1b}[1m\u{1b}[38;5;{}m", skin.search_input_prefix_fg());
+                let csi = format!("\u{1b}[1m{}", skin.search_input_prefix_fg().display_fg());
                 self.search
                     .draw_prefixed_input(w, 0, y, &csi, search_width)?;
                 help_start += search_width;
@@ -882,7 +869,7 @@ impl<'a, 'm> MissionState<'a, 'm> {
         }
         if self.search.input_has_content() {
             // bold, colored foreground
-            let csi_found = format!("\u{1b}[1m\u{1b}[38;5;{}m", skin.found_fg());
+            let csi_found = format!("\u{1b}[1m{}", skin.found_fg().display_fg());
             self.search.add_summary_tstring(&mut t_line, &csi_found);
         }
         let width = self.width as usize;
@@ -902,9 +889,9 @@ impl<'a, 'm> MissionState<'a, 'm> {
         if self.computing {
             write!(
                 w,
-                "\u{1b}[38;5;{}m\u{1b}[48;5;{}m{:^w$}\u{1b}[0m",
-                skin.computing_fg(),
-                skin.computing_bg(),
+                "{}{}{:^w$}\u{1b}[0m",
+                skin.computing_fg().display_fg(),
+                skin.computing_bg().display_bg(),
                 "computing...",
                 w = width
             )?;
@@ -1044,10 +1031,10 @@ impl<'a, 'm> MissionState<'a, 'm> {
             return Ok(());
         }
         let skin = self.mission.job.skin;
-        let csi_found = format!("\u{1b}[1m\u{1b}[38;5;{}m", skin.found_fg()); // bold, colored foreground
+        let csi_found = format!("\u{1b}[1m{}", skin.found_fg().display_fg()); // bold, colored foreground
         let csi_found_selected = format!(
-            "\u{1b}[1m\u{1b}[30m\u{1b}[48;5;{}m",
-            skin.found_selected_bg()
+            "\u{1b}[1m\u{1b}[30m{}",
+            skin.found_selected_bg().display_bg()
         ); // bold, colored background
         #[allow(clippy::cast_possible_truncation)]
         let area = Area::new(


### PR DESCRIPTION

Closes #449

Now in the toml, you can use this syntax: `{ r = 255, g = 255, b = 255 }` to specify an rgb color \
Ansi (0-255) colors are still the same as they were before: a lone integer like `255`
