### PR TITLE
docs: fix spelling in website and doc comments

### DIFF
--- a/src/context_nature.rs
+++ b/src/context_nature.rs
@@ -1,4 +1,4 @@
-/// The kind of projec/context, as it impacts computing features,
+/// The kind of project/context, as it impacts computing features,
 /// files to watch, etc.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ContextNature {

--- a/src/sound/play_sound.rs
+++ b/src/sound/play_sound.rs
@@ -17,7 +17,7 @@ struct Sound {
 /// Get a sound by name, or the default sound if name is None
 ///
 /// Names here are as near as possible from the file names in the
-/// reources directory but without the number, syntax unconsistency and
+/// resources directory but without the number, syntax inconsistency and
 /// redundancy. Resource file names are kept identical to their original
 /// names to ease retrieval for attribution).
 fn get_sound(name: Option<&str>) -> Result<Sound, SoundError> {

--- a/src/tui/app_state.rs
+++ b/src/tui/app_state.rs
@@ -3,6 +3,6 @@ use crate::*;
 #[derive(Default)]
 pub struct AppState {
     pub headless: bool,
-    /// Dimissals and filtering state
+    /// Dismissals and filtering state
     pub filter: Filter,
 }

--- a/src/tui/mission_state.rs
+++ b/src/tui/mission_state.rs
@@ -60,7 +60,7 @@ pub struct MissionState<'a, 'm> {
     /// number of lines hidden on top due to scroll
     scroll: usize,
     /// `item_idx` of the item which was on top on last draw
-    /// (but not necessarily due to volontary scroll)
+    /// (but not necessarily due to voluntary scroll)
     top_item_idx: usize,
     /// `item_idx` of the item the user scrolled to, if any, which we will try to keep on top when
     /// possible

--- a/website/src/community/bacon-dev.md
+++ b/website/src/community/bacon-dev.md
@@ -59,4 +59,4 @@ If you think you might help, as a tester or coder, you're welcome, but please re
 
 Tell me what seems to be unclear or missing.
 
-Or for simple corrections, direcly edit the markdonw files at [the source](https://github.com/Canop/bacon/tree/main/website). The site is built with [ddoc](https://dystroy.org/ddoc).
+Or for simple corrections, directly edit the markdown files at [the source](https://github.com/Canop/bacon/tree/main/website). The site is built with [ddoc](https://dystroy.org/ddoc).

--- a/website/src/community/emacs-bacon.md
+++ b/website/src/community/emacs-bacon.md
@@ -4,7 +4,7 @@
 
 [emacs-bacon](https://seed.pipapo.org/nodes/seed.pipapo.org/rad:zKbD2Y9kERBYScgczMaJBTRfjBhh)
 is an emacs minor-mode, which, combined with bacon, lets you navigate between errors and
-warnings without leaving your editor, just hitting a key. It also syncronizes bacon to show
+warnings without leaving your editor, just hitting a key. It also synchronizes bacon to show
 the current navigated item.
 
 # Development
@@ -23,7 +23,7 @@ At every job end, bacon writes a `.bacon-locations` file with all items (errors,
 test failures, etc.) and for each of them its label, file path, line and column.
 
 It read the `bacon/prefs.toml` and local `bacon.toml`. You can remote-control bacon from emacs
-with the `C-c b` prefix (customizeable) followed by whatever keybindings the bacon preferences
+with the `C-c b` prefix (customizable) followed by whatever keybindings the bacon preferences
 define to send a command to bacon.
 
 You can bind `bacon-next` and other commands to jump to next|prev|first

--- a/website/src/config.md
+++ b/website/src/config.md
@@ -83,7 +83,7 @@ command | the tokens making the command to execute (first one is the executable)
 default_watch | whether to watch default files (`src`, `tests`, `examples`, `build.rs`, and `benches`). When it's set to `false`, only the files in your `watch` parameter are watched | `true`
 env | a map of environment vars, for example `env.LOG_LEVEL="die"` |
 hide_scrollbar | whether to hide the scrollbar (for easier select & copy) | `false`
-kill | a command replacing the default job interruption (platform dependant, `SIGKILL` on unix). For example `kill = ["kill", "-s", "INT"]` |
+kill | a command replacing the default job interruption (platform dependent, `SIGKILL` on unix). For example `kill = ["kill", "-s", "INT"]` |
 ignore | list of glob patterns for files to ignore. Patterns starting with `!` are negations that force-include matching paths, overriding other ignore rules (including `.gitignore`) |
 ignored_lines | regular expressions for lines to ignore |
 extraneous_args | if `false`, the action is run "as is" from `bacon.toml`, eg: no `--all-features` or `--features` inclusion | `true`
@@ -341,7 +341,7 @@ When not defined, the applied default is `first`.
 In the default `bacon.toml`, the `run` and `run-long` jobs have `scroll_anchor = "auto"` which means that:
 
 * if errors were recorded, the default sticky position is the first item
-* if there was no error, the default stiky item is the last one (bacon then acting as `tail` to follow new lines)
+* if there was no error, the default sticky item is the last one (bacon then acting as `tail` to follow new lines)
 
 ## listen
 


### PR DESCRIPTION
Fixes a handful of spelling mistakes in the website docs and in doc comments.

**Website** (`website/src/`)
- `config.md` — "platform dependant" -> "dependent", "default stiky item" -> "sticky"
- `community/bacon-dev.md` — "direcly edit the markdonw files" -> "directly edit the markdown files"
- `community/emacs-bacon.md` — "syncronizes" -> "synchronizes", "customizeable" -> "customizable"

**Doc comments**
- `src/context_nature.rs` — "The kind of projec/context" -> "project/context"
- `src/tui/app_state.rs` — "Dimissals" -> "Dismissals"
- `src/tui/mission_state.rs` — "volontary scroll" -> "voluntary scroll"
- `src/sound/play_sound.rs` — "reources directory" -> "resources directory", "syntax unconsistency" -> "inconsistency"

Comments and documentation only; no code paths touched.

Two things I deliberately left alone:

- `prefered` in `mission_state.rs` is part of the identifiers `prefered_scroll_end`,
  `scroll_to_prefered_end` and `is_scroll_at_prefered_end`. Renaming those is a refactor
  rather than a typo fix, so it seemed better to leave that to you.
- `analyzis` in `src/export/exporter.rs` is a `#[serde(alias = ...)]`, which looks like an
  intentional backwards-compatible spelling, so changing it would break existing configs.
