### PR TITLE
Remove some `flush`es when redrawing

### DIFF
--- a/src/tui/drawing.rs
+++ b/src/tui/drawing.rs
@@ -3,7 +3,7 @@ use {
     anyhow::Result,
     termimad::crossterm::{
         cursor,
-        execute,
+        queue,
         terminal,
     },
 };
@@ -14,7 +14,7 @@ pub fn goto(
     x: u16,
     y: u16,
 ) -> Result<()> {
-    execute!(w, cursor::MoveTo(x, y))?;
+    queue!(w, cursor::MoveTo(x, y))?;
     Ok(())
 }
 
@@ -23,12 +23,12 @@ pub fn goto_line(
     w: &mut W,
     y: u16,
 ) -> Result<()> {
-    execute!(w, cursor::MoveTo(0, y))?;
+    queue!(w, cursor::MoveTo(0, y))?;
     Ok(())
 }
 
 /// Clear from the current position to the end of the line
 pub fn clear_line(w: &mut W) -> Result<()> {
-    execute!(w, terminal::Clear(terminal::ClearType::UntilNewLine))?;
+    queue!(w, terminal::Clear(terminal::ClearType::UntilNewLine))?;
     Ok(())
 }

--- a/src/tui/mission_state.rs
+++ b/src/tui/mission_state.rs
@@ -13,7 +13,7 @@ use {
         MadSkin,
         crossterm::{
             cursor,
-            execute,
+            queue,
             style::{
                 Attribute,
                 Print,
@@ -1145,7 +1145,7 @@ impl<'a, 'm> MissionState<'a, 'm> {
             }
             clear_line(w)?;
             if is_thumb(y.into(), scrollbar) {
-                execute!(w, cursor::MoveTo(area.width, y), Print('▐'.to_string()))?;
+                queue!(w, cursor::MoveTo(area.width, y), Print('▐'.to_string()))?;
             }
         }
         drop(lines);


### PR DESCRIPTION
`bacon` redraws the whole screen on every line of output received from the child process. When processing lots (as in multiple thousands of lines) of output, this takes a significant amount of time.

This PR removes some unnecessary `flush`es that occur during redraw.

On a (simple and unscientific) benchmark of printing 10_000 lines each containing the numbers from 0 to 100, this improves performance. The exact improvement depends on the terminal emulator, the window size (and probably more factors that I didn’t measure). E. g. in an 80×24 Alacritty window (the `empty` job is used to measure startup time):
```console
$ time ./bacon-main empty
./bacon-main empty  0,00s user 0,01s system 20% cpu 0,068 total
$ time ./bacon-main
./bacon-main  0,70s user 0,77s system 97% cpu 1,519 total
$ time ./bacon-reduce-flushing
./bacon-reduce-flushing  0,35s user 0,08s system 74% cpu 0,582 total
$ time ./produce-output
[... 10_000 lines]
./produce-output  0,01s user 0,04s system 50% cpu 0,087 total
```

Tested with this `bacon.toml`:
```toml
default_job = "produce-output"

[jobs.produce-output]
command = ["./produce-output"]
need_stdout = true
background = false
on_success = "quit"

[jobs.empty]
command = ["echo", "42"]
need_stdout = true
background = false
on_success = "quit"
```